### PR TITLE
Fix for Issue #12 - Update mangapark domain

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -567,6 +567,7 @@ var defaultSettings = {
 // @include        http://*.thewebcomic.com/*
 // @include        http://www.mangapark.com/*
 // @include        http://mangapark.com/*
+// @include        http*://mangapark.me/*
 // @include        http://www.manga-go.com/*
 // @include        http://www.comicstriplibrary.org/display/*
 // @include        http://comicstriplibrary.org/display/*
@@ -3167,7 +3168,7 @@ var paginas = [
 		scrollx:	'R',
 		layelem:	'//div[@id="divImage"]',
 	},
-	{	url:	'mangatank.com|mangapark.com|mangawindow.com',
+	{	url:	'mangatank.com|mangapark.com|mangawindow.com|mangapark.me',
 		img:	[['.img-link img']],
 		style:	'#wcr_div{line-height:1;}',
 		js:		function(dir){


### PR DESCRIPTION
#12 Webcomic reader has a working configuration for mangapark. mangapark.com currently redirects to mangapark.me as the working domain, so small update is needed to restore functionality. 2 lines added/updated for a quick fix.

First time I've tried to make a pull request for anything on GitHub, so hopefully I'm doing this right.