### PR TITLE
Fix page navigation on dumbingofage.com

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -2213,8 +2213,8 @@ var paginas = [
 	{	url:	'shortpacked.com',
 		img:	'http://www.shortpacked.com/comics/'
 	},
-  {	url:	'dumbingofage.com',
-		js:		function(dir){ window.removeEventListener('load', breakbadtoys, true); breakbadtoys = null; },
+	{	url:	'dumbingofage.com',
+		js:	function(dir){ window.removeEventListener('load', breakbadtoys, true); breakbadtoys = null; },
 	},
 	{	url:	'axecop.com',
 		img:	[['#comic img']],

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -919,7 +919,6 @@ var usarb64 = confBool('b64_images', false);
 */
 
 var paginas = [
-
 	{	url:	'penny-arcade.com',
 		img:	[['#comicFrame img']],
 		fixurl:	function(url, img, link, pos){return url.replace("http:","")},
@@ -2213,6 +2212,9 @@ var paginas = [
 	},
 	{	url:	'shortpacked.com',
 		img:	'http://www.shortpacked.com/comics/'
+	},
+  {	url:	'dumbingofage.com',
+		js:		function(dir){ window.removeEventListener('load', breakbadtoys, true); breakbadtoys = null; },
 	},
 	{	url:	'axecop.com',
 		img:	[['#comic img']],


### PR DESCRIPTION
This is a follow-up fix for #20 improving on the technique used in 8163eea and fixing wcr for http://dumbingofage.com.

This fix should prevent the jumpbar script from messing with wcr when the former gets executed before the later. (8163eea apparently only works when jumpbar gets executed *after* wcr).

I'm not 100% confident in my use of the `window` object inside GM, but I got wcr 100% working on dumbingofage with it.