### PR TITLE
Remove debugger in run_script()

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -4610,7 +4610,6 @@ var flipControls = false; //invertir flechas/clicks/botones para mangas u otros 
 var clickImgNavigates = confBool('clickImgNavigates', true);
 
 function run_script(){
-	debugger;
 	try{
 		if(useHistoryAPI && history.pushState){
 			setEvt(window, 'popstate', function(evt){


### PR DESCRIPTION
Hello,

Thank you for continuing this great script. I noticed that there was a `debugger` in one of the global functions. I think it would be smart to remove it because I personally don't think this should be in a prodution file.

First PR, hopefully the first of many! 

Thanks!

