### PR TITLE
Fix mangahere.co

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -43,7 +43,7 @@ var defaultSettings = {
 // ==UserScript==
 // @name           Webcomic Reader
 // @author         Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
-// @version        2017.07.04
+// @version        2017.09.27
 // @namespace      http://userscripts.org/scripts/show/59842
 // @description    Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
 // @homepageURL    https://github.com/anka-213/webcomic_reader#readme
@@ -418,7 +418,7 @@ var defaultSettings = {
 // @include        http://www.wigucomics.com/*
 // @include        http://www.mankin-trad.net/*
 // @include        http://mankin-trad.net/*
-// @include        http://www.mangahere.co/*
+// @include        https://www.mangahere.co/*
 // @include        http://es.mangahere.co/*
 // @include        http://www.scarygoround.com/*
 // @include        http://scarygoround.com/*


### PR DESCRIPTION
Fix mangahere.co switching to https by default.
Also bump script version to push update.

Although the person posting for issue #82 does have a nice fix for all sites switching to between http and https without updating the script everytime.