### PR TITLE
Fixes for various sites, added in several additional ones (Updated: 2019-08-06)

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -4791,8 +4791,7 @@ var paginas = [
         img:    [['#submissionImg']],
         back:	['//span[@class="parsed_nav_links"]//a[contains(.,"PREV")]'],
         next:	['//span[@class="parsed_nav_links"]//a[contains(.,"NEXT")]'],
-		first:	'.="FIRST"',
-        extra:  [['.maintable']]
+		first:	['//span[@class="parsed_nav_links"]//a[contains(.,"FIRST")]']
 	}
     // End of sites
 	/*

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -43,7 +43,7 @@ var defaultSettings = {
 // ==UserScript==
 // @name           Webcomic Reader
 // @author         Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
-// @version        2019.02.12
+// @version        2019.07.01
 // @license        MIT
 // @namespace      http://userscripts.org/scripts/show/59842
 // @description    Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
@@ -1635,7 +1635,8 @@ var paginas = [
 		img:	['//div[@id="comic"]/img']
 	},
 	{	url:	'*.katbox.net',
-		img:	[['.webcomic-image img']]
+		img:	[['.webcomic-image img']],
+        style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
 	},
 	{	url:	'gipcomic.com',
 		img:	'/pages/',
@@ -4141,10 +4142,10 @@ var paginas = [
 	{
 		url:	'egscomics.com',
 		img:	'http://egscomics.com/comics/',
-		back:	'@rel="prev"',
-		next:	'@rel="next"',
-		first:	'@rel="first"',
-		last:	'@rel="last"',
+		back:	[['.cc-prev']],
+		next:	[['.cc-next']],
+		first:	[['.cc-first']],
+		last:	[['.cc-last']],
 		extra:	['<div id="wrapper"><div id="leftarea">',[['#news']],'</div></div>'],
 	},
 	{
@@ -4768,7 +4769,9 @@ var paginas = [
     {	url:    'atomic-robo.com',
         img:    ['//img[contains(@src, "/comics/")]'],
         back:   [['.cc-prev']],
-        next:   [['.cc-next']]
+        next:   [['.cc-next']],
+        first:	[['.cc-first']],
+		last:	[['.cc-last']]
 	},
     // End of sites
 	/*

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -43,7 +43,7 @@ var defaultSettings = {
 // ==UserScript==
 // @name           Webcomic Reader
 // @author         Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
-// @version        2018.08.26
+// @version        2019.02.12
 // @license        MIT
 // @namespace      http://userscripts.org/scripts/show/59842
 // @description    Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
@@ -467,8 +467,7 @@ var defaultSettings = {
 // @include        http://www.truefork.org/*
 // @include        http://truefork.org/*
 // @include        http://www.aorange.com/*
-// @include        http://www.thewotch.com/*
-// @include        http://thewotch.com/*
+// @include        http*://www.thewotch.com/*
 // @include        http*://cheer.sailorsun.org/*
 // @include        http://montrose.is/sgvy/archives/*
 // @include        http://www.montrose.is/sgvy/archives/*
@@ -603,7 +602,7 @@ var defaultSettings = {
 // @include        http://krakowstudios.com/*
 // @include        http://www.aikoniacomic.com/*
 // @include        http://aikoniacomic.com/*
-// @include        http*	://www.grrlpowercomic.com/*
+// @include        http*://grrlpowercomic.com/*
 // @include        http://www.poisonedminds.com/*
 // @include        http://poisonedminds.com/*
 // @include        http://nodwick.humor.gamespy.com/*
@@ -826,6 +825,7 @@ var defaultSettings = {
 // @match          *://www.mngdoom.com/*/*
 // @match          *://kimchicuddles.com/post/*
 // @match          *://marktrail.com/*
+// @include        http*://www.atomic-robo.com/*
 // ==/UserScript==
 
 // End of includes
@@ -2306,7 +2306,7 @@ var paginas = [
 	},
 	{	url:	'nerfnow.com',
 		img:	[['#comic img']],
-		extra:	[[['.comment']]],
+		extra:	[[['.comment']]]
 	},
 	{	url:	'zapcomic.com',
 		img:	'http://www.zapcomic.com?comic_object='
@@ -2494,9 +2494,9 @@ var paginas = [
 		next:	'@rel="next"'
 	},
 	{	url:	'cheer.sailorsun.org',
-                img:	[['#comic img']],
-                back:   [[['.comic-nav-previous']]],
-                next:   [[['.comic-nav-next']]]
+        img:	[['#comic img']],
+        back:   [[['.comic-nav-previous']]],
+        next:   [[['.comic-nav-next']]]
 	},
 	{	url:	'drunkduck.com',
 		img:	[['#comic img']],
@@ -2524,10 +2524,10 @@ var paginas = [
 		extra:	[[['img[src^="comix/"]', '<br/>', 1]]]
 	},
 	{	url:	'thewotch.com',
-                back:   [[['.comic-nav-previous']]],
-                next:   [[['.comic-nav-next']]],
+        back:   [[['.comic-nav-previous']]],
+        next:   [[['.comic-nav-next']]],
 		extra:	[[['.comments']]],
-                style:	'#wcr_imagen{max-height:100% !important;max-width:90vw !important;width:auto !important;height:auto !important;}'
+        style:	'#wcr_imagen{max-height:100% !important;max-width:90vw !important;width:auto !important;height:auto !important;}'
 	},
 	{	url:	'thedevilbear.com',
 		img:	'comixx/'
@@ -4764,6 +4764,11 @@ var paginas = [
 	{
 		url:	'marktrail.com',
 		img:	[['#comic img']],
+	},
+    {	url:    'atomic-robo.com',
+        img:    ['//img[contains(@src, "/comics/")]'],
+        back:   [['.cc-prev']],
+        next:   [['.cc-next']]
 	},
     // End of sites
 	/*

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -4141,12 +4141,12 @@ var paginas = [
 	},
 	{
 		url:	'egscomics.com',
-		img:	'http://egscomics.com/comics/',
+		img:    [['#cc-comic']],
 		back:	[['.cc-prev']],
 		next:	[['.cc-next']],
 		first:	[['.cc-first']],
 		last:	[['.cc-last']],
-		extra:	['<div id="wrapper"><div id="leftarea">',[['#news']],'</div></div>'],
+		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>'],
 	},
 	{
 		url:	'http://mspfanventures.com/',

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -826,7 +826,6 @@ var defaultSettings = {
 // @match		  *://kimchicuddles.com/post/*
 // @match		  *://marktrail.com/*
 // @include		http*://www.atomic-robo.com/*
-// @include		http*://www.dhscomix.com/comics*
 // @include		http*://www.furaffinity.net/view/*
 // @include		http*://www.furaffinity.net/full/*
 // ==/UserScript==
@@ -4792,14 +4791,6 @@ var paginas = [
 		first:	[['.cc-first']],
 		last:	[['.cc-last']],
 		style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
-	},
-	{	url:	'dhscomix.com/comics',
-		img:	['//div[@id="content"]//img'],
-		back:	'img[contains(@src, "nav_prevpage")]',
-		next:	'img[contains(@src, "nav_nextpage")]',
-		first:	'img[contains(@src, "nav_firstpage")]',
-		last:	'img[contains(@src, "nav_newpage")]',
-        extra:  [['//p[@align="center"]//img']]
 	},
 	{	url:	'furaffinity.net',
 		img:	[['#submissionImg']],

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -131,8 +131,8 @@ var defaultSettings = {
 // @include		http://pennyandaggie.com/*
 // @include		http://www.darkbolt.com/*
 // @include		http://darkbolt.com/*
-// @include		http://www.egscomics.com/*
 // @include		http://egscomics.com/*
+// @include		http://www.egscomics.com/*
 // @include		http://www.the-gutters.com/*
 // @include		http://www.punchanpie.net/*
 // @include		http://punchanpie.net/*
@@ -4142,8 +4142,10 @@ var paginas = [
 		next:	'text()="next >"',
 		first:	'text()="|<"',
 	},
+    //Needed Two Seperate EGS entries to handle the www and non-www URLs
+    //--[
 	{
-		url:	'egscomics.com',
+		url:	'http://www.egscomics.com',
 		img:	[['#cc-comic']],
 		back:   [['.cc-prev']],
 		next:   [['.cc-next']],
@@ -4151,9 +4153,20 @@ var paginas = [
 		last:	[['.cc-last']],
 		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>'],
 		fixurl:	function(url, img, link){
-					return url.replace('http://egscomics', 'http://www.egscomics');
+        if(link) return url.replace('http://egscomics', 'http://www.egscomics');
+		return url;
 		}
 	},
+    {
+		url:	'http://egscomics.com',
+		img:	[['#cc-comic']],
+		back:   [['.cc-prev']],
+		next:   [['.cc-next']],
+		first:	[['.cc-first']],
+		last:	[['.cc-last']],
+		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>']
+	},
+    //]--
 	{
 		url:	'http://mspfanventures.com/',
 		img:	[['article img']],
@@ -4781,11 +4794,12 @@ var paginas = [
 		style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
 	},
 	{	url:	'dhscomix.com/comics',
-		img:	['div[@id="content"]//img'],
+		img:	['//div[@id="content"]//img'],
 		back:	'img[contains(@src, "nav_prevpage")]',
 		next:	'img[contains(@src, "nav_nextpage")]',
 		first:	'img[contains(@src, "nav_firstpage")]',
-		last:	'img[contains(@src, "nav_newpage")]'
+		last:	'img[contains(@src, "nav_newpage")]',
+        extra:  [['//p[@align="center"]//img']]
 	},
 	{	url:	'furaffinity.net',
 		img:	[['#submissionImg']],

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -197,8 +197,8 @@ var defaultSettings = {
 // @include        http://www.gocomics.com/*
 // @exclude        http://www.gocomics.com/
 // @exclude        http://www.gocomics.com/?*
-// @include        http://www.gunnerkrigg.com/*
-// @include        http://gunnerkrigg.com/*
+// @include        http*://www.gunnerkrigg.com/*
+// @include        http*://gunnerkrigg.com/*
 // @include        http://www.ho-lo.co.il/*
 // @include        http://www.jeffzugale.com/*
 // @include        http://www.threepanelsoul.com/*
@@ -826,6 +826,7 @@ var defaultSettings = {
 // @match          *://kimchicuddles.com/post/*
 // @match          *://marktrail.com/*
 // @include        http*://www.atomic-robo.com/*
+// @include        http*://www.dhscomix.com/comics*
 // ==/UserScript==
 
 // End of includes
@@ -4141,12 +4142,15 @@ var paginas = [
 	},
 	{
 		url:	'egscomics.com',
-		img:	'http://egscomics.com/comics/',
-		back:	'@rel="prev"',
-		next:	'@rel="next"',
-		first:	'@rel="first"',
-		last:	'@rel="last"',
+		img:    [['#cc-comic']],
+        back:   [['.cc-prev']],
+        next:   [['.cc-next']],
+        first:	[['.cc-first']],
+		last:	[['.cc-last']],
 		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>'],
+        fixurl:	function(url, img, link){
+					return url.replace('http://egscomics', 'http://www.egscomics');
+        }
 	},
 	{
 		url:	'http://mspfanventures.com/',
@@ -4767,12 +4771,20 @@ var paginas = [
 		img:	[['#comic img']],
 	},
     {	url:    'atomic-robo.com',
-        img:    ['//img[contains(@src, "/comics/")]'],
+        img:    [['#cc-comic']],
         back:   [['.cc-prev']],
         next:   [['.cc-next']],
         first:	[['.cc-first']],
-		last:	[['.cc-last']]
+		last:	[['.cc-last']],
+        style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
 	},
+    {	url:    'dhscomix.com/comics',
+        img:    ['div[@id="content"]//img'],
+        back:	'img[contains(@src, "nav_prevpage")]',
+		next:	'img[contains(@src, "nav_nextpage")]',
+		first:	'img[contains(@src, "nav_firstpage")]',
+		last:	'img[contains(@src, "nav_newpage")]'
+	}
     // End of sites
 	/*
 	,

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -43,7 +43,7 @@ var defaultSettings = {
 // ==UserScript==
 // @name           Webcomic Reader
 // @author         Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
-// @version        2019.07.01
+// @version        2019.08.06
 // @license        MIT
 // @namespace      http://userscripts.org/scripts/show/59842
 // @description    Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
@@ -827,6 +827,8 @@ var defaultSettings = {
 // @match          *://marktrail.com/*
 // @include        http*://www.atomic-robo.com/*
 // @include        http*://www.dhscomix.com/comics*
+// @include        http*://www.furaffinity.net/view/*
+// @include        http*://www.furaffinity.net/full/*
 // ==/UserScript==
 
 // End of includes
@@ -4784,6 +4786,13 @@ var paginas = [
 		next:	'img[contains(@src, "nav_nextpage")]',
 		first:	'img[contains(@src, "nav_firstpage")]',
 		last:	'img[contains(@src, "nav_newpage")]'
+	},
+    {	url:    'furaffinity.net',
+        img:    [['#submissionImg']],
+        back:	['//span[@class="parsed_nav_links"]//a[contains(.,"PREV")]'],
+        next:	['//span[@class="parsed_nav_links"]//a[contains(.,"NEXT")]'],
+		first:	'.="FIRST"',
+        extra:  [['.maintable']]
 	}
     // End of sites
 	/*

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -828,6 +828,23 @@ var defaultSettings = {
 // @include		http*://www.atomic-robo.com/*
 // @include		http*://www.furaffinity.net/view/*
 // @include		http*://www.furaffinity.net/full/*
+// @include		http*://www.dhscomix.com/comics*
+// @include		http*://www.dhscomix.com/bcomics*
+// @include		http*://www.dhscomix.com/dcomics*
+// @include		http*://www.dhscomix.com/decomics*
+// @include		http*://www.dhscomix.com/dfcomics*
+// @include		http*://www.dhscomix.com/dhscomics*
+// @include		http*://www.dhscomix.com/fcomics*
+// @include		http*://www.dhscomix.com/jcomics*
+// @include		http*://www.dhscomix.com/kcomics*
+// @include		http*://www.dhscomix.com/lcomics*
+// @include		http*://www.dhscomix.com/mercomics*
+// @include		http*://www.dhscomix.com/ocomics*
+// @include		http*://www.dhscomix.com/pcomics*
+// @include		http*://www.dhscomix.com/scomics*
+// @include		http*://www.dhscomix.com/tcomics*
+// @include		http*://www.dhscomix.com/wcomics*
+
 // ==/UserScript==
 
 // End of includes
@@ -4798,6 +4815,34 @@ var paginas = [
 		next:	['//span[@class="parsed_nav_links"]//a[contains(.,"NEXT")]'],
 		first:	['//span[@class="parsed_nav_links"]//a[contains(.,"FIRST")]'],
 		extra:  [['//table[@class="maintable"]//tbody//tr//table[@class="maintable"]']]
+	},
+	{	url:	'dhscomix.com/comics', //Random Encounters
+		img:	['//div[@id="content"]//img'],
+        extra:	[['//div[@id="content"]']],
+		back:	'img[contains(@src, "nav_prevpage")]',
+		next:	'img[contains(@src, "nav_nextpage")]',
+        //Work around for multiple comic images on a page
+        style:  '#wcr_imagen{display: none !important;}\ndiv#content p:nth-child(1){display: none !important}', //Hides img and displays only extra
+        js:	function(dir){ //Copied from Webtoon's entry. Thanks to who ever did that
+				// Makes it so anything within extra will be nav-clickable
+				var elemImagen = document.querySelectorAll('#wcr_extra');
+				setEvt(elemImagen, 'click', imgClick);
+				setEvt(elemImagen, 'mousemove', imgCursor);
+				},
+	},
+	{	url:	'dhscomix.com/bcomics|dhscomix.com/dcomics|dhscomix.com/decomics|dhscomix.com/dfcomics|dhscomix.com/dhscomics|dhscomix.com/fcomics|dhscomix.com/jcomics|dhscomix.com/kcomics|dhscomix.com/lcomics|dhscomix.com/mercomics|dhscomix.com/ocomics|dhscomix.com/pcomics|dhscomix.com/scomics|dhscomix.com/tcomics|dhscomix.com/wcomics', //All the other DHS Comix Comics
+		img:	['//div[@id="content"]//img'],
+        extra:	[['//div[@id="content"]']],
+		back:	'img[contains(@src, "previous")]',
+		next:	'img[contains(@src, "next")]',
+        //Work around for multiple comic images on a page
+        style:  '#wcr_imagen{display: none !important;}\ndiv#content p:nth-child(1){display: none !important}', //Hides img and displays only extra
+        js:	function(dir){ //Copied from whoever did Webtoon's entry
+				// Makes it so anything within extra will be nav-clickable
+				var elemImagen = document.querySelectorAll('#wcr_extra');
+				setEvt(elemImagen, 'click', imgClick);
+				setEvt(elemImagen, 'mousemove', imgCursor);
+				},
 	}
 	// End of sites
 	/*

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -41,794 +41,794 @@ var defaultSettings = {
 };
 
 // ==UserScript==
-// @name           Webcomic Reader
-// @author         Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
-// @version        2019.08.06
-// @license        MIT
-// @namespace      http://userscripts.org/scripts/show/59842
-// @description    Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
-// @homepageURL    https://github.com/anka-213/webcomic_reader#readme
-// @supportURL     https://github.com/anka-213/webcomic_reader/issues
-// @updateURL      https://raw.githubusercontent.com/anka-213/webcomic_reader/master/webcomic_reader.user.js
-// @updatetype     24
-// @grant          GM_getValue
-// @grant          GM_setValue
-// @grant          GM_deleteValue
-// @grant          GM_xmlhttpRequest
-// @grant          GM_registerMenuCommand
-// @grant          GM_openInTab
-// @include        http://www.sluggy.com/*
-// @include        http://sluggy.com/*
-// @include        http://www.penny-arcade.com/comic*
-// @include        http://penny-arcade.com/comic*
-// @include        https://www.penny-arcade.com/comic*
-// @include        https://penny-arcade.com/comic*
-// @match          *://*.xkcd.com/*
-// @include        http://www.giantitp.com/*
-// @include        http://www.dilbert.com/strip/*
-// @include        http://dilbert.com/strip/*
-// @include        http://hf.dilbert.com/strip/*
-// @include        http://www.explosm.net/*
-// @include        http://explosm.net/*
-// @include        http://www.nuklearpower.com/*
-// @include        http://www.reallifecomics.com/*
-// @include        http://reallifecomics.com/*
-// @include        http://www.pvponline.com/*
-// @include        http://pvponline.com/*
-// @include        http://www.brawlinthefamily.com/*
-// @include        http://drmcninja.com/*
-// @include        http://www.vgcats.com/*/*
-// @include        http://www.phdcomics.com/*
-// @include        http://www.cad-comic.com/*
-// @match          *://*.smbc-comics.com/*
-// @include        http://abstrusegoose.com/*
-// @include        http://thedoghousediaries.com/*
-// @include        http://www.erfworld.com/*
-// @include        http://es.juanelo.net/*/*
-// @include        http://mangastream.com/*
-// @include        http://www.mangastream.com/*
-// @include        http://readms.net/*
-// @include        https://mangastream.com/*
-// @include        https://www.mangastream.com/*
-// @include        https://readms.net/*
-// @include        http://www.readms.net/*
-// @include        http://readms.com/*
-// @include        http://www.qwantz.com/*
-// @include        http://qwantz.com/*
-// @include        http://www.2pstart.com/*/*
-// @include        http://www.spaceavalanche.com/*
-// @include        http://www.gunshowcomic.com/*
-// @include        http://gunshowcomic.com/*
-// @include        http://www.terrorisland.net/*
-// @include        http://nedroid.com/*
-// @include        http://manga.animea.net/*
-// @include        http://www.bobandgeorge.com/*
-// @include        http://bobandgeorge.com/*
-// @include        http://www.shamusyoung.com/*
-// @include        http://www.stationv3.com/*
-// @include        http://www.lfgcomic.com/page/*
-// @include        http://lfgcomic.com/page/*
-// @include        http://www.gpf-comics.com/*
-// @match          *://*.questionablecontent.net/*
-// @include        http://miscellanea.wellingtongrey.net/*
-// @include        http://www.daisyowl.com/*
-// @include        http://daisyowl.com/*
-// @include        http://www.hyperdeathbabies.com/*
-// @include        http://www.mangatoshokan.com/*
-// @include        http://amultiverse.com/*
-// @include        http://wondermark.com/*
-// @include        http://www.amazingsuperpowers.com/*
-// @include        http://www.anymanga.com/*
-// @include        http://anymanga.com/*
-// @match          *://fanfox.net/*
-// @match          *://m.fanfox.net/*
-// @include        http://www.leasticoulddo.com/*
-// @include        http://leasticoulddo.com/*
-// @include        http://www.sinfest.net/*
-// @include        http://www.crfh.net/*
-// @include        http://crfh.net/*
-// @include        http://www.pennyandaggie.com/*
-// @include        http://pennyandaggie.com/*
-// @include        http://www.darkbolt.com/*
-// @include        http://darkbolt.com/*
-// @include        http://www.egscomics.com/*
-// @include        http://egscomics.com/*
-// @include        http://www.the-gutters.com/*
-// @include        http://www.punchanpie.net/*
-// @include        http://punchanpie.net/*
-// @include        http://noneedforbushido.com/*
-// @include        http://www.teahousecomic.com/*
-// @include        http://www.applegeeks.com/*
-// @include        http://applegeeks.com/*
-// @include        http://www.mangareader.net/*
-// @include        http://stoptazmo.com/*
-// @include        http://www.arcamax.com/*
-// @include        http://www.nettserier.no/*
-// @include        http://nettserier.no/*
-// @include        http*://www.nerfnow.com/*
-// @include        http://www.virtualshackles.com/*
-// @include        http://www.little-gamers.com/*
-// @include        http://www.digitalunrestcomic.com/*
-// @include        http://digitalunrestcomic.com/*
-// @include        http://www.duelinganalogs.com/*
-// @include        http://www.actiontrip.com/*
-// @include        http://actiontrip.com/*
-// @include        http://www.myextralife.com/*
-// @include        http://www.mondaynightcrew.com/*
-// @include        http://mondaynightcrew.com/*
-// @include        http://notinventedhe.re/*
-// @include        http://www.unshelved.com/*
-// @include        https://www.eviscerati.org/comics*
-// @include        http://read.mangashare.com/*
-// @include        http://haven-reader.net/*
-// @include        http://www.manga2u.me/*
-// @include        http://manga2u.me/*
-// @include        http://buttersafe.com/*
-// @include        http://www.romanticallyapocalyptic.com/*
-// @include        http://romanticallyapocalyptic.com/*
-// @include        http://www.somethingpositive.net/*
-// @include        http://somethingpositive.net/*
-// @include        http://www.rhymes-with-witch.com/*
-// @include        http://rhymes-with-witch.com/*
-// @include        http://www.superstupor.com/*
-// @include        http://superstupor.com/*
-// @include        http://www.misfile.com/*
-// @include        http://www.asofterworld.com/*
-// @include        http://asofterworld.com/*
-// @include        http://www.achewood.com/*
-// @include        http://achewood.com/*
-// @include        http://www.act-i-vate.com/*
-// @include        http://act-i-vate.com/*
-// @include        http://www.biggercheese.com/*
-// @include        http://biggercheese.com/*
-// @include        http://www.gwscomic.com/*
-// @include        http://gwscomic.com/*
-// @include        http://www.fonflatter.de/*
-// @include        http://www.ruthe.de/*
-// @include        http://ruthe.de/*
-// @include        http://www.daybydaycartoon.com/*
-// @include        http://daybydaycartoon.com/*
-// @include        http://www.dieselsweeties.com/*
-// @include        http://dieselsweeties.com/*
-// @include        http://www.foxtrot.com/*
-// @include        http://www.csectioncomics.com/*
-// @include        http://garfieldminusgarfield.net/*
-// @include        http://www.girlgeniusonline.com/*
-// @include        http://www.gocomics.com/*
-// @exclude        http://www.gocomics.com/
-// @exclude        http://www.gocomics.com/?*
-// @include        http*://www.gunnerkrigg.com/*
-// @include        http*://gunnerkrigg.com/*
-// @include        http://www.ho-lo.co.il/*
-// @include        http://www.jeffzugale.com/*
-// @include        http://www.threepanelsoul.com/*
-// @include        http://threepanelsoul.com/*
-// @match          *://*.oglaf.com/*
-// @include        http://www.kevinandkell.com/*
-// @include        http://kevinandkell.com/*
-// @include        http://kittyhawkcomic.com/*
-// @include        http://www.lackadaisycats.com/comic.php*
-// @include        http://lackadaisycats.com/comic.php*
-// @include        http://www.lukesurl.com/*
-// @include        http://mycardboardlife.com/*
-// @include        http*://megatokyo.com/*
-// @include        http*://www.megatokyo.it/*
-// @include        http*://www.megatokyo.de/*
-// @include        http://ex2.unixmanga.net/*
-// @include        http://noreasoncomics.com/*
-// @include        http://www.pixelcomic.net/*
-// @include        http://pixelcomic.net/*
-// @include        http://www.redmeat.com/*
-// @include        http://redmeat.com/*
-// @include        http://sexylosers.com/*
-// @include        http://www.doonesbury.com/*
-// @include        http://stalebacon.com/*
-// @include        http://www.mangaeden.com/*
-// @include        http://www.pbfcomics.com/*
-// @include        http://tjandamal.com/*
-// @include        http://sfeertheory.littlefoolery.com/*
-// @include        http://wanderingones.com/*
-// @include        http://www.big-big-truck.com/ayiw/*
-// @include        http://big-big-truck.com/ayiw/*
-// @include        http://wapsisquare.com/*
-// @include        http://www.wastedtalent.ca/*
-// @include        http://www.wulffmorgenthaler.com/*
-// @include        http://wulffmorgenthaler.com/*
-// @include        http://www.weregeek.com/*
-// @include        http://*.katbox.net/*
-// @include        http://*.keenspace.com/*
-// @include        http://*.comicgenesis.com/*
-// @include        http://www.beanleafpress.com/*
-// @include        http://gipcomic.com/*
-// @include        http://www.theoswaldchronicles.com/*
-// @include        http://www.awkwardzombie.com/*
-// @include        http://awkwardzombie.com/*
-// @include        http://*.seraph-inn.com/*
-// @include        https://www.fakku.net/manga/*
-// @include        https://www.fakku.net/doujinshi/*
-// @include        http://www.deadwinter.cc/*
-// @include        http://deadwinter.cc/*
-// @include        http://www.loveisintheblood.com/*
-// @include        http://rhapsodies.wpmorse.com/*
-// @include        http://www.piratesofmars.com/*
-// @include        http://www.soulless-comic.com/*
-// @include        http://www.earthsongsaga.com/vol*
-// @include        http://rainchildstudios.com/strawberry/*
-// @include        http://www.goblinscomic.org/*
-// @include        http://www.venusenvycomic.com/*
-// @include        http://venusenvycomic.com/*
-// @include        http://www.meekcomic.com/*
-// @include        http://www.dominic-deegan.com/*
-// @include        http://dominic-deegan.com/*
-// @include        http://yafgc.net/*
-// @include        http://www.sdamned.com/*
-// @include        http://www.twolumps.net/*
-// @include        http://twolumps.net/*
-// @include        http://www.precociouscomic.com/*
-// @include        http://precociouscomic.com/*
-// @include        http://betweenplaces.spiderforest.com/*
-// @include        http://specialschool.spiderforest.com/*
-// @include        http://requiem.spiderforest.com/*
-// @include        http://sevensmith.net/chirault/*
-// @include        http://www.junglestudio.com/roza/*
-// @include        http://www.dream-scar.net/*
-// @include        http://dream-scar.net/*
-// @include        http://www.tryinghuman.com/*
-// @include        http://tryinghuman.com/*
-// @include        http://www.thedreamercomic.com/*
-// @include        http://thedreamercomic.com/
-// @include        http://www.shazzbaa.com/*
-// @include        http://shazzbaa.com/*
-// @match          *://*.sandraandwoo.com/*
-// @include        http://www.freakangels.com/*
-// @include        http://comics.com/*
-// @include        http://www.sakanacomic.com/*
-// @include        http://www.jaygeefisher.com/*
-// @include        http://jaygeefisher.com/*
-// @include        http://www.doujin-moe.us/*
-// @include        http://keychain.patternspider.net/*
-// @include        http://www.collectedcurios.com/*
-// @include        http://www.doomies.com/*
-// @include        http://doomies.com/*
-// @include        http://www.qgmindpolice.com/*
-// @include        http://www.slowwave.com/*
-// @include        http://slowwave.com/*
-// @include        http://www.sylvanmigdal.com/*
-// @include        http://sylvanmigdal.com/*
-// @include        http://www.c.urvy.org/*
-// @include        http://c.urvy.org/*
-// @include        http://www.the-artiste.net/*
-// @include        http://www.doublefine.com/*
-// @include        http://www.survivingtheworld.net/*
-// @include        http://survivingtheworld.net/*
-// @include        http://view.thespectrum.net/*
-// @include        http://www.mangavolume.com/*
-// @include        http://nonadventures.com/*
-// @include        http://www.robandelliot.cycomics.com/*
-// @include        http://robandelliot.cycomics.com/*
-// @include        http://soulsymphonycomic.com/*
-// @include        http://www.blastwave-comic.com/*
-// @include        http://www.channelate.com/*
-// @include        http://www.picturesforsadchildren.com/*
-// @include        http://picturesforsadchildren.com/*
-// @include        http://www.optipess.com/*
-// @include        http://www.drawuntilitsfunny.com/*
-// @include        http://beardfluff.com/*
-// @include        http://lawlscomic.com/*
-// @include        http://www.maakies.com/*
-// @include        http://www.lefthandedtoons.com/*
-// @include        http://trollscience.com/*
-// @include        http://www.diggercomic.com/*
-// @include        http://luciphurrsimps.com/*
-// @include        http://nikkisprite.com/*
-// @include        http://planet-nowhere.com/*
-// @include        http://www.mysisterthefreak.com/*
-// @include        http://www.gronkcomic.com/*
-// @include        http://www.redsplanet.com/*
-// @include        http://www.cowshell.com/*
-// @include        http://everblue-comic.com/*
-// @include        http://tmkcomic.depleti.com/*
-// @include        http://www.remindblog.com/*
-// @include        http://inkdolls.com/*
-// @include        http://www.terra-comic.com/*
-// @include        http://lovecraftismissing.com/*
-// @include        http://www.redmoonrising.org/*
-// @include        http://www.khaoskomix.com/*
-// @include        http://ipaintgirls.com/*
-// @include        http://memoria.valice.net/*
-// @include        http://www.twilightlady.com/*
-// @include        http://submanga.com/*
-// @include        http*://e-hentai.org/*
-// @include        http://crazytje.be/*
-// @include        http://www.tenmangas.com/*
-// @include        http://tenmangas.com/*
-// @include        http://www.tenmanga.com/*
-// @include        http://tenmanga.com/*
-// @include        http://www.perveden.com/*
-// @include        http://reader.imangascans.org/*
-// @include        http://www.bittersweetcandybowl.com/*
-// @include        http://www.doujintoshokan.com/*
-// @include        http://www.imagebam.com/*
-// @include        http://www.exploitationnow.com/*
-// @include        http://www.otakuworks.com/*
-// @include        http://h-manga.info/*
-// @include        http://basicinstructions.net/*
-// @include        http://www.insaneyetisquirrel.com/*
-// @include        http://*.kukudm.com/comiclist/*/*/*
-// @include        http://*.kukudm.net/comiclist/*/*/*
-// @include        http://mh.socomic.com/comiclist/*/*/*
-// @include        http://www.socomic.net/comiclist/*/*/*
-// @include        http://www.webcomicsnation.com/*
-// @include        http://www.pawn.se/*
-// @include        http://www.rpgworldcomic.com/*
-// @include        http://rpgworldcomic.com/*
-// @include        http://maskedretriever.com/*
-// @include        http://www.missmab.com/*
-// @include        http://www.lookwhatibroughthome.com/*
-// @include        http://hijinksensue.com/*
-// @include        http://www.darthsanddroids.net/*
-// @include        http://darthsanddroids.net/*
-// @include        http://www.harkavagrant.com/*
-// @include        http://www.turbosloth.net/*
-// @include        http://turbosloth.net/*
-// @include        http://www.walkinginsquares.com/*
-// @include        http://walkinginsquares.com/*
-// @include        http://dresdencodak.com/*
-// @include        http://www.straysonline.com/comic/*
-// @include        http://straysonline.com/comic/*
-// @include        http://www.emi-art.com/*
-// @include        http://emi-art.com/*
-// @include        http://www.dragonball-multiverse.com/*
-// @include        http://insanesoft.org/fanfyria/*
-// @include        http://*.snafu-comics.com/*
-// @include        http://www.wayfarersmoon.com/*
-// @include        http://wayfarersmoon.com/*
-// @include        http://*.smackjeeves.com/*
-// @include        http://www.10kcommotion.com/*
-// @include        http://10kcommotion.com/*
-// @include        http://somemangas.com/*
-// @include        http://www.multiplexcomic.com/*
-// @include        http://multiplexcomic.com/*
-// @include        http://www.johnandjohn.nl/index.php?*wltypeid=1*
-// @include        http://www.sorcery101.net/*
-// @include        http://www.treadingground.com/*
-// @include        http://www.jerkcity.com/*
-// @include        http://jerkcity.com/*
-// @include        http://www.kiwiblitz.com/*
-// @include        http://thepunchlineismachismo.com/*
-// @include        http://kafkaskoffee.com/*
-// @include        http://occasionalcomics.com/*
-// @include        http://www.zombieboycomics.com/*
-// @include        http://www.babyblues.com/*
-// @include        http://babyblues.com/*
-// @include        http://www.bearandtiger.com/*
-// @include        http://mangatopia.net/*
-// @include        http*://exhentai.org/*
-// @include        http://www.wigucomics.com/*
-// @include        http://www.mankin-trad.net/*
-// @include        http://mankin-trad.net/*
-// @include        http://www.mangahere.co/*
-// @include        http://es.mangahere.co/*
-// @include        http://www.mangahere.cc/*
-// @include        http://es.mangahere.cc/*
-// @include        http://www.scarygoround.com/*
-// @include        http://scarygoround.com/*
-// @include        http://www.schlockmercenary.com/*
-// @include        http://www.warehousecomic.com/*
-// @include        http://warehousecomic.com/*
-// @include        http://www.tnemrot.com/*
-// @include        http://www.holiday-wars.com/*
-// @include        http://www.zapcomic.com/*
-// @include        http://www.twokinds.net/*
-// @include        http://twokinds.net/*
-// @include        http://www.dumbingofage.com/*
-// @include        http://www.shortpacked.com/*
-// @include        http://www.itswalky.com/*
-// @include        http://itswalky.com/*
-// @include        http://www.evildivacomics.com/*
-// @include        http://axecop.com/*
-// @include        http://www.somethingofthatilk.com/*
-// @include        http://somethingofthatilk.com/*
-// @include        http://www.reddit.com/
-// @include        http://www.reddit.com/?*
-// @include        http://www.reddit.com/r/*
-// @exclude        http://www.reddit.com/*/comments/*
-// @include        http://blankitcomics.com/*
-// @include        http://www.anime-source.com/*
-// @include        http://anime-source.com/*
-// @include        http://www.mangarush.com/*
-// @include        http://www.citymanga.com/*/*/*
-// @include        http://citymanga.com/*/*/*
-// @include        http://www.dctp.ws/*/V*.html
-// @include        http://dctp.ws/*/V*.html
-// @include        http://doctorcatmd.com/*
-// @include        http://www.sheldoncomics.com/*
-// @include        http://sheldoncomics.com/*
-// @include        http://luscious.net/*/pictures/*
-// @include        http://old.lu.scio.us/hentai/albums/*
-// @exclude        http://old.lu.scio.us/hentai/albums/*/page/*
-// @include        http://www.geekculture.com/joyoftech/*
-// @include        http://www.basketcasecomix.com/*
-// @include        http://www.geeklifecomic.com/*
-// @include        http://www.realmofatland.com/*
-// @include        http://realmofatland.com/*
-// @include        http://thedoujin.com/index.php/pages/*
-// @include        http://eatmanga.com/*
-// @include        http://eatmanga.me/*
-// @include        http://www.oslevadosdabreca.com/*
-// @include        http://www.thedevilbear.com/*
-// @include        http://thedevilbear.com/*
-// @include        http://www.bladebunny.com/*
-// @include        http://www.exiern.com/*
-// @include        http://nsfw-comix.com/*
-// @include        http://jaynaylor.com/*
-// @include        http://www.anelnoath.com/*
-// @include        http://www.faans.com/*
-// @include        http://www.truefork.org/*
-// @include        http://truefork.org/*
-// @include        http://www.aorange.com/*
-// @include        http*://www.thewotch.com/*
-// @include        http*://cheer.sailorsun.org/*
-// @include        http://montrose.is/sgvy/archives/*
-// @include        http://www.montrose.is/sgvy/archives/*
-// @include        http://www.drunkduck.com/*
-// @include        http://drunkduck.com/*
-// @include        http://www.ephralon.de/seekers_detailed.php*
-// @include        http://ephralon.de/seekers_detailed.php*
-// @include        http://www.terinu.com/*
-// @include        http://terinu.com/*
-// @include        http://dcisgoingtohell.com/*
-// @include        http://las-historietas.blogspot.com/*
-// @include        http://www.palcomix.com/*
-// @include        http://palcomix.com/*
-// @include        http://www.palcomix.org/*
-// @include        http://palcomix.org/*
-// @include        http://www.whiteninjacomics.com/*
-// @include        http://whiteninjacomics.com/*
-// @include        http://www.apenotmonkey.com/*
-// @include        http://malandchad.com/*
-// @include        http://www.goodmanga.net/*
-// @include        http://www.digitalcomicmuseum.com/*
-// @include        http://digitalcomicmuseum.com/*
-// @include        http://goldenagecomics.co.uk/*
-// @include        http://fourcolorshadows.blogspot.com/*
-// @include        http://thehorrorsofitall.blogspot.com/*
-// @include        *//bato.to/chapter*
-// @include        http://www.eegra.com/*
-// @include        http://www.octopuspie.com/*
-// @include        http://www.lovemenicecomic.com/*
-// @include        http://www.ju-ni.net/*
-// @include        http://ju-ni.net/*
-// @include        http://blog.saveapathea.com/*
-// @include        http://www.dead-philosophers.com/*
-// @include        http://www.nerd-theater.com/*
-// @include        http://nerd-theater.com/*
-// @include        http://lackadaisy.foxprints.com/comic.php*
-// @include        http://www.mangastream.to/*
-// @include        http://www.kingfeatures.com/*
-// @include        http://kingfeatures.com/*
-// @include        http://www.thezombiehunters.com/*
-// @include        http://thezombiehunters.com/*
-// @include        http://www.bugcomic.com/*
-// @include        http://www.interrobangstudios.com/*
-// @include        http://interrobangstudios.com/*
-// @include        http://www.hlcomic.com/*
-// @include        http://hlcomic.com/*
-// @include        http://syacartoonist.com/*
-// @include        http://satwcomic.com/*
-// @include        http://stupidfox.net/*
-// @include        http://www.casualvillain.com/*
-// @include        http://fanboys-online.com/*
-// @include        http://www.girlswithslingshots.com/*
-// @include        http://www.mntgaiden.com/*
-// @include        http://lovehentaimanga.com/*
-// @include        http://ravensdojo.com/*
-// @include        http://freefall.purrsia.com/*
-// @include        http://www.mangachapter.net/*
-// @include        http://www.mangachapter.me/*
-// @include        http://www.shd-wk.com/*
-// @include        http://shd-wk.com/*
-// @include        http://www.pepsaga.com/*
-// @include        http://slimythief.com/*
-// @include        http://www.pebbleversion.com/*
-// @include        http://pebbleversion.com/*
-// @include        http://mentalcatproductions.com/*
-// @include        http://schoolbites.net/*
-// @include        http://www.accurseddragon.com/*
-// @include        http://www.krakowstudios.com/*
-// @include        http://www.stringtheorycomic.com/*
-// @include        http://www.supercrash.net/*
-// @include        http://loveandcapes.com/*
-// @include        http://victorycomic.comicgenesis.com/*
-// @include        http://magellanverse.com/*
-// @include        http://www.evil-comic.com/*
-// @include        http://flakypastry.runningwithpencils.com/*
-// @include        http://www.pointguardian.com/*
-// @include        http://gogetaroomie.chloe-art.com/*
-// @include        http://legendofbill.com/*
-// @include        http://www.springiette.net/*
-// @include        http://springiette.net/*
-// @include        http://www.vampirecheerleaders.net/*
-// @include        http://www.paranormalmysterysquad.com/*
-// @include        http://www.draculaeverlasting.com/*
-// @include        http://www.amazingagentjennifer.com/*
-// @include        http://mindmistress.comicgenesis.com/*
-// @include        http://www.evernightcomic.com/*
-// @include        http://www.xindm.cn/*
-// @include        http://mh2.xindm.cn/*
-// @include        http://www.manga123.com/read/*
-// @include        http://manga.redhawkscans.com/*
-// @include        http://slide.extrascans.net/*
-// @include        http://*.thewebcomic.com/*
-// @include        http://www.mangapark.com/*
-// @include        http://mangapark.com/*
-// @include        http*://mangapark.me/*
-// @include        http://www.manga-go.com/*
-// @include        http://www.comicstriplibrary.org/display/*
-// @include        http://comicstriplibrary.org/display/*
-// @include        http://www.wirepop.com/*
-// @include        http://wirepop.com/*
-// @include        http://www.fantasyrealmsonline.com/manga/*
-// @include        http://foolrulez.org/*
-// @include        http://reader.japanzai.com/*
-// @include        http://www.psychopandas.com/reader/*
-// @include        http://psychopandas.com/reader/*
-// @include        http://www.ourmanga.com/*
-// @include        http://readonline.egscans.org/*
-// @include        http://read.egscans.com/*
-// @include        http://reader.eternalmanga.net/*
-// @include        http://gallery.ryuutama.com/*
-// @include        http://*.tiraecol.net/*
-// @include        http://tiraecol.net/*
-// @include        http://www.conejofrustrado.com/*
-// @include        http://www.e2w-illustration.com/*
-// @include        http://2gamerz.com/*
-// @include        http://reader.fth-scans.com/*
-// @include        http://www.simple-scans.com/*
-// @include        http://simple-scans.com/*
-// @include        http://www.mymangaspot.com/*
-// @include        http://comic.naver.com/*
-// @include        http://www.peteristhewolf.com/*
-// @include        http://peteristhewolf.com/*
-// @include        http://www.wlpcomics.com/*
-// @include        http://wlpcomics.com/*
-// @include        http://www.mangatraders.com/*
-// @include        http://hentaifromhell.net/*
-// @include        http://trenchescomic.com/*
-// @include        http://www.sakicow.com/reader/*
-// @include        http://sakicow.com/reader/*
-// @include        http://www.goominet.com/unspeakable-vault/*
-// @include        http://www.doesnotplaywellwithothers.com/*
-// @include        http://krakowstudios.com/*
-// @include        http://www.aikoniacomic.com/*
-// @include        http://aikoniacomic.com/*
-// @include        http*://grrlpowercomic.com/*
-// @include        http://www.poisonedminds.com/*
-// @include        http://poisonedminds.com/*
-// @include        http://nodwick.humor.gamespy.com/*
-// @include        http://www.the-whiteboard.com/*
-// @include        http://the-whiteboard.com/*
-// @include        http://www.mezzacotta.net/*
-// @include        http://www.hbrowse.com/*
-// @include        http://aptitude.surfacingpoint.com/*
-// @include        http://www.bardsworth.com/*
-// @include        http://fancyadventures.com/*
-// @include        http://www.chron.com/entertainment/comics-games/comic/*
-// @include        http://www.purplepussy.net/*
-// @include        http://purplepussy.net/*
-// @include        http://www.heroeslocales.com/bunsen/*
-// @include        http://www.readhentaionline.com/*
-// @include        http://readhentaionline.com/*
-// @include        http://www.darklegacycomics.com/*
-// @include        http://darklegacycomics.com/*
-// @include        http://candicomics.com/*
-// @include        http://www.buckocomic.com/*
-// @include        http://bearmageddon.com/*
-// @include        http://betweenfailures.net/*
-// @include        http://www.sisterclaire.com/*
-// @include        http://www.fayerwayer.com/*
-// @include        http://www.niubie.com/*
-// @include        http://www.awesomehospital.com/*
-// @include        http://ars.userfriendly.org/cartoons/*
-// @include        http://www.friendswithboys.com/*
-// @include        http://www.mangago.com/*
-// @include        http://www.jesusandmo.net/*
-// @include        http://www.calamitiesofnature.com/*
-// @include        http://www.rosalarian.com/*
-// @include        http://rosalarian.com/*
-// @include        http://dungeond.com/*
-// @include        http://www.irregularwebcomic.net/*
-// @include        http://adistantsoil.com/*
-// @include        http://comic.nodwick.com/*
-// @include        http://ffn.nodwick.com/*
-// @include        http://ps238.nodwick.com/*
-// @include        http://kronos.mcanime.net/*
-// @include        http://www.ghastlycomic.com/*
-// @include        http://thedevilspanties.com/*
-// @include        http://walkingdeadbr.com/*displayimage.php*
-// @include        http://www.mangapanda.com/*
-// @include        http://mangable.com/*
-// @include        http://dragonflyscans.org/*
-// @include        http://readincesthentai.com/*
-// @include        http://www.animephile.com/*
-// @include        http://hentaistreamer.com/*
-// @match          *://kissmanga.com/*
-// @include        http://www.mangatank.com/*
-// @include        http://www.snowflakescomic.com/*
-// @include        http://mangafox.mobi/*
-// @include        http://www.mangainn.me/*
-// @include        http://invisiblebread.com/*
-// @include        http://onlinereader.mangapirate.net/*
-// @include        http://www.8comic.com/love/*
-// @include        http://8comic.com/love/*
-// @include        http://www.mangahead.com/*
-// @include        http://www.mangahead.me/*
-// @include        http://mangahead.com/*
-// @include        http://www.vickifox.com/*
-// @include        http://www.spinnyverse.com/*
-// @include        http://zenpencils.com/*
-// @include        http://wootmanga.com/*
-// @include        http://hentai2read.com/*
-// @include        http://m.hentai2read.com/*
-// @include        http://komikmy.com/*/*/*
-// @include        http://www.hentaifr.net/doujinshisheng.php*
-// @include        http://www.commissionedcomic.com/*
-// @include        http://www.mangasky.com/*
-// @include        http://mangapirate.net/*
-// @include        http://nomanga.com/*
-// @include        http://hentaimangaonline.com/*
-// @include        http://webcomics.yaoi911.com/*
-// @include        http://www.whompcomic.com/*
-// @include        http://actiontimebuddies.com/*
-// @include        http://www.superbrophybrothers.com/*
-// @include        http://www.surasplace.com/*
-// @include        http://surasplace.com/*
-// @include        http://fallensyndicate.com/reader/*
-// @include        http://www.nekothekitty.net/*
-// @include        http://curtailedcomic.com/*
-// @include        http://www.wiemanga.com/*
-// @include        http://img.wiemanga.com/*
-// @include        http://hentai4manga.com/*
-// @include        http://bradcolbow.com/*
-// @include        http://www.gaomanga.com/*
-// @include        http://www.theherobiz.com/*
-// @include        http://guildedage.net/*
-// @include        http://betweenfailures.com/*
-// @include        http://www.claudeandmonet.com/*
-// @include        http://phobia.subcultura.es/tira/*
-// @include        http://www.manga-tu.be/*
-// @include        http://de.ninemanga.com/*
-// @include        http://proxer.me/*
-// @include        http://www.demanga.com/*
-// @include        http://www.meinmanga.com/*
-// @include        http*://www.senmanga.com/*
-// @include        http*://raw.senmanga.com/*
-// @include        http://www.mangaesta.net/*
-// @include        http://www.mabuns.web.id/*
-// @include        http://www.manga4indo.com/*
-// @include        http://www.bloomingfaeries.com/*
-// @include        http://www.friendshipscans.com/*
-// @include        http://neechan.net/*
-// @include        http://www.komikid.com/*
-// @include        http://komikid.com/*
-// @include        http://blog.komikid.com/*
-// @include        http://www.findchaos.com/*
-// @include        http://chaoslife.findchaos.com/*
-// @include        http://moonoverjune.com/*
-// @include        http://www.shadbase.com/*
-// @include        http://www.shagbase.com/*
-// @include        http://www.mrlovenstein.com/*
-// @include        http://www.anticscomic.com/*
-// @include        http://octopuns.blogspot.com/*
-// @include        http://www.onemanga.me/*
-// @include        http://mangacow.co/*
-// @include        http://www.mangabee.com/*
-// @include        http://mangadoom.co/*
-// @include        http://www.powernapcomic.com/*
-// @include        http://mangachrome.com/*
-// @include        http://www.7manga.com/*
-// @include        http://7manga.com/*
-// @include        http://www.mangadevil.com/*
-// @include        http://mangadevil.com/*
-// @include        http://www.mangamofo.com/*
-// @include        http://*.hentai.ms/*
-// @include        http://view.mangamonger.com/*
-// @include        http://blackbird.ashen-ray.com/*
-// @include        http://carciphona.com/*
-// @include        http://ahs-comic.com/*
-// @include        http://www.gogetaroomie.com/*
-// @include        http://gogetaroomie.com/*
-// @include        http://*.thecomicseries.com/*
-// @include        http://www.sleepymaid.com/gallery/displayimage.php*
-// @include        http://sleepymaid.com/gallery/displayimage.php*
-// @include        http://www.squid-ops.com/*
-// @include        http://squid-ops.com/*
-// @include        http://www.endcomic.com/*
-// @include        http://www.thenoobcomic.com/*
-// @include        http://thenoobcomic.com/*
-// @include        http://zizki.com/*
-// @include        http://*.zizki.com/*
-// @include        http://pururin.com/*
-// @include        http://www.thedailyblink.com/*
-// @include        http://mangabandits.net/*
-// @include        http://www.neumanga.com/*
-// @include        http://www.pecintakomik.com/*
-// @include        http://www.schizmatic.com/*
-// @include        http://schizmatic.com/*
-// @include        http://www.yuri-ism.net/*
-// @include        http://www.bringbackroomies.com/*
-// @match          *://*.blindsprings.com/*
-// @match          *://*.forgottenordercomic.com/*
-// @include        http://www.wtfcomics.com/*archive.html?*
-// @include        http://wtfcomics.com/*archive.html?*
-// @include        http://www.olympusoverdrive.com/index.php?*
-// @include        http://olympusoverdrive.com/index.php?*
-// @include        http://*gucomics.com/*
-// @include        http://www.punksandnerds.com/*
-// @include        http://*.troutcave.net/*
-// @include        http://www.berserkersdaughter.com/*
-// @include        http://gingerhaze.com/nimona/comic/*
-// @include        http://aiacrowd.com/*
-// @include        http://aspect.waywardstudios.net/*
-// @include        http://chirault.sevensmith.net/*
-// @include        http://cucumber.gigidigi.com/*
-// @include        http://filteredfuzz.com/*
-// @include        http://www.dorktower.com/*
-// @include        http://mangajoy.com/*
-// @include        http://nhentai.net/*
-// @include        http://www.hejibits.com/*
-// @include        http://mangaindo.co/*
-// @include        http://5.79.87.81/*
-// @include        http://www.gao-subs.com/*
-// @include        http://www.mangawindow.com/*
-// @include        http://mangawindow.com/*
-// @include        http://omgmanga.com/*
-// @include        http://paintraincomic.com/*
-// @include        http://extrafabulouscomics.com/*
-// @include        http://hellocomic.com/*
-// @include        http://*.hellocomic.com/*
-// @include        http://www.feywinds.com/comic/*
-// @include        http://www.omgbeaupeep.com/*
-// @include        http://orgymania.net/*
-// @include        http://mspaintadventures.com/*
-// @include        http://www.mspaintadventures.com/*
-// @include        http://mspfanventures.com/
-// @include        http://agc.deskslave.org/comic_viewer.html
-// @include        http://www.readmanga.today/*
-// @include        http://www.mangatown.com/manga/*
-// @include        http://www.mymanga.me/manga/*
-// @include        http://www.legostargalactica.net/*
-// @include        http://hentaihere.com/m/*/*/*
-// @include        http://gomanga.co/reader/read*
-// @include        http://mangasee.co/manga/*
-// @include        http://mangaseeonline.us/*
-// @include        http://mangafap.com/image/*
-// @include        http://*.keenspot.com/*
-// @include        http://dynasty-scans.com/*
-// @include        http://*.dynasty-scans.com/*
-// @include        http://mangafast.online/manga/*
-// @include        http://www.demonicscans.com/FoOlSlide/read/*
-// @include        http://raws.yomanga.co/read/*
-// @include        http://*.dm5.com/m*
-// @include        https://nhentai.net/g/*
-// @include        http://www.marycagle.com/*
-// @include        http://www.sleeplessdomain.com/*
-// @include        http://www.webtoons.com/*
-// @match          *://*.tsumino.com/Read/View/*
-// @include        http://incase.buttsmithy.com/comic/*
-// @include        http://leylinescomic.com/comics/*
-// @include        http://project-apollo.net/mos/*
-// @include        http://afterstrife.com/?p*
-// @include        https://hitomi.la/reader/*
-// @include        https://danbooru.donmai.us/*
-// @include        https://manga.madokami.al/reader/*
-// @match          *://www.mngdoom.com/*/*
-// @match          *://kimchicuddles.com/post/*
-// @match          *://marktrail.com/*
-// @include        http*://www.atomic-robo.com/*
-// @include        http*://www.dhscomix.com/comics*
-// @include        http*://www.furaffinity.net/view/*
-// @include        http*://www.furaffinity.net/full/*
+// @name		   Webcomic Reader
+// @author		 Javier Lopez <ameboide@gmail.com> https://github.com/ameboide , fork by v4Lo https://github.com/v4Lo and by anka-213 http://github.com/anka-213
+// @version		2019.08.06
+// @license		MIT
+// @namespace	  http://userscripts.org/scripts/show/59842
+// @description	Can work on almost any webcomic/manga page, preloads 5 or more pages ahead (or behind), navigates via ajax for instant-page-change, lets you use the keyboard, remembers your progress, and it's relatively easy to add new sites
+// @homepageURL	https://github.com/anka-213/webcomic_reader#readme
+// @supportURL	 https://github.com/anka-213/webcomic_reader/issues
+// @updateURL	  https://raw.githubusercontent.com/anka-213/webcomic_reader/master/webcomic_reader.user.js
+// @updatetype	 24
+// @grant		  GM_getValue
+// @grant		  GM_setValue
+// @grant		  GM_deleteValue
+// @grant		  GM_xmlhttpRequest
+// @grant		  GM_registerMenuCommand
+// @grant		  GM_openInTab
+// @include		http://www.sluggy.com/*
+// @include		http://sluggy.com/*
+// @include		http://www.penny-arcade.com/comic*
+// @include		http://penny-arcade.com/comic*
+// @include		https://www.penny-arcade.com/comic*
+// @include		https://penny-arcade.com/comic*
+// @match		  *://*.xkcd.com/*
+// @include		http://www.giantitp.com/*
+// @include		http://www.dilbert.com/strip/*
+// @include		http://dilbert.com/strip/*
+// @include		http://hf.dilbert.com/strip/*
+// @include		http://www.explosm.net/*
+// @include		http://explosm.net/*
+// @include		http://www.nuklearpower.com/*
+// @include		http://www.reallifecomics.com/*
+// @include		http://reallifecomics.com/*
+// @include		http://www.pvponline.com/*
+// @include		http://pvponline.com/*
+// @include		http://www.brawlinthefamily.com/*
+// @include		http://drmcninja.com/*
+// @include		http://www.vgcats.com/*/*
+// @include		http://www.phdcomics.com/*
+// @include		http://www.cad-comic.com/*
+// @match		  *://*.smbc-comics.com/*
+// @include		http://abstrusegoose.com/*
+// @include		http://thedoghousediaries.com/*
+// @include		http://www.erfworld.com/*
+// @include		http://es.juanelo.net/*/*
+// @include		http://mangastream.com/*
+// @include		http://www.mangastream.com/*
+// @include		http://readms.net/*
+// @include		https://mangastream.com/*
+// @include		https://www.mangastream.com/*
+// @include		https://readms.net/*
+// @include		http://www.readms.net/*
+// @include		http://readms.com/*
+// @include		http://www.qwantz.com/*
+// @include		http://qwantz.com/*
+// @include		http://www.2pstart.com/*/*
+// @include		http://www.spaceavalanche.com/*
+// @include		http://www.gunshowcomic.com/*
+// @include		http://gunshowcomic.com/*
+// @include		http://www.terrorisland.net/*
+// @include		http://nedroid.com/*
+// @include		http://manga.animea.net/*
+// @include		http://www.bobandgeorge.com/*
+// @include		http://bobandgeorge.com/*
+// @include		http://www.shamusyoung.com/*
+// @include		http://www.stationv3.com/*
+// @include		http://www.lfgcomic.com/page/*
+// @include		http://lfgcomic.com/page/*
+// @include		http://www.gpf-comics.com/*
+// @match		  *://*.questionablecontent.net/*
+// @include		http://miscellanea.wellingtongrey.net/*
+// @include		http://www.daisyowl.com/*
+// @include		http://daisyowl.com/*
+// @include		http://www.hyperdeathbabies.com/*
+// @include		http://www.mangatoshokan.com/*
+// @include		http://amultiverse.com/*
+// @include		http://wondermark.com/*
+// @include		http://www.amazingsuperpowers.com/*
+// @include		http://www.anymanga.com/*
+// @include		http://anymanga.com/*
+// @match		  *://fanfox.net/*
+// @match		  *://m.fanfox.net/*
+// @include		http://www.leasticoulddo.com/*
+// @include		http://leasticoulddo.com/*
+// @include		http://www.sinfest.net/*
+// @include		http://www.crfh.net/*
+// @include		http://crfh.net/*
+// @include		http://www.pennyandaggie.com/*
+// @include		http://pennyandaggie.com/*
+// @include		http://www.darkbolt.com/*
+// @include		http://darkbolt.com/*
+// @include		http://www.egscomics.com/*
+// @include		http://egscomics.com/*
+// @include		http://www.the-gutters.com/*
+// @include		http://www.punchanpie.net/*
+// @include		http://punchanpie.net/*
+// @include		http://noneedforbushido.com/*
+// @include		http://www.teahousecomic.com/*
+// @include		http://www.applegeeks.com/*
+// @include		http://applegeeks.com/*
+// @include		http://www.mangareader.net/*
+// @include		http://stoptazmo.com/*
+// @include		http://www.arcamax.com/*
+// @include		http://www.nettserier.no/*
+// @include		http://nettserier.no/*
+// @include		http*://www.nerfnow.com/*
+// @include		http://www.virtualshackles.com/*
+// @include		http://www.little-gamers.com/*
+// @include		http://www.digitalunrestcomic.com/*
+// @include		http://digitalunrestcomic.com/*
+// @include		http://www.duelinganalogs.com/*
+// @include		http://www.actiontrip.com/*
+// @include		http://actiontrip.com/*
+// @include		http://www.myextralife.com/*
+// @include		http://www.mondaynightcrew.com/*
+// @include		http://mondaynightcrew.com/*
+// @include		http://notinventedhe.re/*
+// @include		http://www.unshelved.com/*
+// @include		https://www.eviscerati.org/comics*
+// @include		http://read.mangashare.com/*
+// @include		http://haven-reader.net/*
+// @include		http://www.manga2u.me/*
+// @include		http://manga2u.me/*
+// @include		http://buttersafe.com/*
+// @include		http://www.romanticallyapocalyptic.com/*
+// @include		http://romanticallyapocalyptic.com/*
+// @include		http://www.somethingpositive.net/*
+// @include		http://somethingpositive.net/*
+// @include		http://www.rhymes-with-witch.com/*
+// @include		http://rhymes-with-witch.com/*
+// @include		http://www.superstupor.com/*
+// @include		http://superstupor.com/*
+// @include		http://www.misfile.com/*
+// @include		http://www.asofterworld.com/*
+// @include		http://asofterworld.com/*
+// @include		http://www.achewood.com/*
+// @include		http://achewood.com/*
+// @include		http://www.act-i-vate.com/*
+// @include		http://act-i-vate.com/*
+// @include		http://www.biggercheese.com/*
+// @include		http://biggercheese.com/*
+// @include		http://www.gwscomic.com/*
+// @include		http://gwscomic.com/*
+// @include		http://www.fonflatter.de/*
+// @include		http://www.ruthe.de/*
+// @include		http://ruthe.de/*
+// @include		http://www.daybydaycartoon.com/*
+// @include		http://daybydaycartoon.com/*
+// @include		http://www.dieselsweeties.com/*
+// @include		http://dieselsweeties.com/*
+// @include		http://www.foxtrot.com/*
+// @include		http://www.csectioncomics.com/*
+// @include		http://garfieldminusgarfield.net/*
+// @include		http://www.girlgeniusonline.com/*
+// @include		http://www.gocomics.com/*
+// @exclude		http://www.gocomics.com/
+// @exclude		http://www.gocomics.com/?*
+// @include		http*://www.gunnerkrigg.com/*
+// @include		http*://gunnerkrigg.com/*
+// @include		http://www.ho-lo.co.il/*
+// @include		http://www.jeffzugale.com/*
+// @include		http://www.threepanelsoul.com/*
+// @include		http://threepanelsoul.com/*
+// @match		  *://*.oglaf.com/*
+// @include		http://www.kevinandkell.com/*
+// @include		http://kevinandkell.com/*
+// @include		http://kittyhawkcomic.com/*
+// @include		http://www.lackadaisycats.com/comic.php*
+// @include		http://lackadaisycats.com/comic.php*
+// @include		http://www.lukesurl.com/*
+// @include		http://mycardboardlife.com/*
+// @include		http*://megatokyo.com/*
+// @include		http*://www.megatokyo.it/*
+// @include		http*://www.megatokyo.de/*
+// @include		http://ex2.unixmanga.net/*
+// @include		http://noreasoncomics.com/*
+// @include		http://www.pixelcomic.net/*
+// @include		http://pixelcomic.net/*
+// @include		http://www.redmeat.com/*
+// @include		http://redmeat.com/*
+// @include		http://sexylosers.com/*
+// @include		http://www.doonesbury.com/*
+// @include		http://stalebacon.com/*
+// @include		http://www.mangaeden.com/*
+// @include		http://www.pbfcomics.com/*
+// @include		http://tjandamal.com/*
+// @include		http://sfeertheory.littlefoolery.com/*
+// @include		http://wanderingones.com/*
+// @include		http://www.big-big-truck.com/ayiw/*
+// @include		http://big-big-truck.com/ayiw/*
+// @include		http://wapsisquare.com/*
+// @include		http://www.wastedtalent.ca/*
+// @include		http://www.wulffmorgenthaler.com/*
+// @include		http://wulffmorgenthaler.com/*
+// @include		http://www.weregeek.com/*
+// @include		http://*.katbox.net/*
+// @include		http://*.keenspace.com/*
+// @include		http://*.comicgenesis.com/*
+// @include		http://www.beanleafpress.com/*
+// @include		http://gipcomic.com/*
+// @include		http://www.theoswaldchronicles.com/*
+// @include		http://www.awkwardzombie.com/*
+// @include		http://awkwardzombie.com/*
+// @include		http://*.seraph-inn.com/*
+// @include		https://www.fakku.net/manga/*
+// @include		https://www.fakku.net/doujinshi/*
+// @include		http://www.deadwinter.cc/*
+// @include		http://deadwinter.cc/*
+// @include		http://www.loveisintheblood.com/*
+// @include		http://rhapsodies.wpmorse.com/*
+// @include		http://www.piratesofmars.com/*
+// @include		http://www.soulless-comic.com/*
+// @include		http://www.earthsongsaga.com/vol*
+// @include		http://rainchildstudios.com/strawberry/*
+// @include		http://www.goblinscomic.org/*
+// @include		http://www.venusenvycomic.com/*
+// @include		http://venusenvycomic.com/*
+// @include		http://www.meekcomic.com/*
+// @include		http://www.dominic-deegan.com/*
+// @include		http://dominic-deegan.com/*
+// @include		http://yafgc.net/*
+// @include		http://www.sdamned.com/*
+// @include		http://www.twolumps.net/*
+// @include		http://twolumps.net/*
+// @include		http://www.precociouscomic.com/*
+// @include		http://precociouscomic.com/*
+// @include		http://betweenplaces.spiderforest.com/*
+// @include		http://specialschool.spiderforest.com/*
+// @include		http://requiem.spiderforest.com/*
+// @include		http://sevensmith.net/chirault/*
+// @include		http://www.junglestudio.com/roza/*
+// @include		http://www.dream-scar.net/*
+// @include		http://dream-scar.net/*
+// @include		http://www.tryinghuman.com/*
+// @include		http://tryinghuman.com/*
+// @include		http://www.thedreamercomic.com/*
+// @include		http://thedreamercomic.com/
+// @include		http://www.shazzbaa.com/*
+// @include		http://shazzbaa.com/*
+// @match		  *://*.sandraandwoo.com/*
+// @include		http://www.freakangels.com/*
+// @include		http://comics.com/*
+// @include		http://www.sakanacomic.com/*
+// @include		http://www.jaygeefisher.com/*
+// @include		http://jaygeefisher.com/*
+// @include		http://www.doujin-moe.us/*
+// @include		http://keychain.patternspider.net/*
+// @include		http://www.collectedcurios.com/*
+// @include		http://www.doomies.com/*
+// @include		http://doomies.com/*
+// @include		http://www.qgmindpolice.com/*
+// @include		http://www.slowwave.com/*
+// @include		http://slowwave.com/*
+// @include		http://www.sylvanmigdal.com/*
+// @include		http://sylvanmigdal.com/*
+// @include		http://www.c.urvy.org/*
+// @include		http://c.urvy.org/*
+// @include		http://www.the-artiste.net/*
+// @include		http://www.doublefine.com/*
+// @include		http://www.survivingtheworld.net/*
+// @include		http://survivingtheworld.net/*
+// @include		http://view.thespectrum.net/*
+// @include		http://www.mangavolume.com/*
+// @include		http://nonadventures.com/*
+// @include		http://www.robandelliot.cycomics.com/*
+// @include		http://robandelliot.cycomics.com/*
+// @include		http://soulsymphonycomic.com/*
+// @include		http://www.blastwave-comic.com/*
+// @include		http://www.channelate.com/*
+// @include		http://www.picturesforsadchildren.com/*
+// @include		http://picturesforsadchildren.com/*
+// @include		http://www.optipess.com/*
+// @include		http://www.drawuntilitsfunny.com/*
+// @include		http://beardfluff.com/*
+// @include		http://lawlscomic.com/*
+// @include		http://www.maakies.com/*
+// @include		http://www.lefthandedtoons.com/*
+// @include		http://trollscience.com/*
+// @include		http://www.diggercomic.com/*
+// @include		http://luciphurrsimps.com/*
+// @include		http://nikkisprite.com/*
+// @include		http://planet-nowhere.com/*
+// @include		http://www.mysisterthefreak.com/*
+// @include		http://www.gronkcomic.com/*
+// @include		http://www.redsplanet.com/*
+// @include		http://www.cowshell.com/*
+// @include		http://everblue-comic.com/*
+// @include		http://tmkcomic.depleti.com/*
+// @include		http://www.remindblog.com/*
+// @include		http://inkdolls.com/*
+// @include		http://www.terra-comic.com/*
+// @include		http://lovecraftismissing.com/*
+// @include		http://www.redmoonrising.org/*
+// @include		http://www.khaoskomix.com/*
+// @include		http://ipaintgirls.com/*
+// @include		http://memoria.valice.net/*
+// @include		http://www.twilightlady.com/*
+// @include		http://submanga.com/*
+// @include		http*://e-hentai.org/*
+// @include		http://crazytje.be/*
+// @include		http://www.tenmangas.com/*
+// @include		http://tenmangas.com/*
+// @include		http://www.tenmanga.com/*
+// @include		http://tenmanga.com/*
+// @include		http://www.perveden.com/*
+// @include		http://reader.imangascans.org/*
+// @include		http://www.bittersweetcandybowl.com/*
+// @include		http://www.doujintoshokan.com/*
+// @include		http://www.imagebam.com/*
+// @include		http://www.exploitationnow.com/*
+// @include		http://www.otakuworks.com/*
+// @include		http://h-manga.info/*
+// @include		http://basicinstructions.net/*
+// @include		http://www.insaneyetisquirrel.com/*
+// @include		http://*.kukudm.com/comiclist/*/*/*
+// @include		http://*.kukudm.net/comiclist/*/*/*
+// @include		http://mh.socomic.com/comiclist/*/*/*
+// @include		http://www.socomic.net/comiclist/*/*/*
+// @include		http://www.webcomicsnation.com/*
+// @include		http://www.pawn.se/*
+// @include		http://www.rpgworldcomic.com/*
+// @include		http://rpgworldcomic.com/*
+// @include		http://maskedretriever.com/*
+// @include		http://www.missmab.com/*
+// @include		http://www.lookwhatibroughthome.com/*
+// @include		http://hijinksensue.com/*
+// @include		http://www.darthsanddroids.net/*
+// @include		http://darthsanddroids.net/*
+// @include		http://www.harkavagrant.com/*
+// @include		http://www.turbosloth.net/*
+// @include		http://turbosloth.net/*
+// @include		http://www.walkinginsquares.com/*
+// @include		http://walkinginsquares.com/*
+// @include		http://dresdencodak.com/*
+// @include		http://www.straysonline.com/comic/*
+// @include		http://straysonline.com/comic/*
+// @include		http://www.emi-art.com/*
+// @include		http://emi-art.com/*
+// @include		http://www.dragonball-multiverse.com/*
+// @include		http://insanesoft.org/fanfyria/*
+// @include		http://*.snafu-comics.com/*
+// @include		http://www.wayfarersmoon.com/*
+// @include		http://wayfarersmoon.com/*
+// @include		http://*.smackjeeves.com/*
+// @include		http://www.10kcommotion.com/*
+// @include		http://10kcommotion.com/*
+// @include		http://somemangas.com/*
+// @include		http://www.multiplexcomic.com/*
+// @include		http://multiplexcomic.com/*
+// @include		http://www.johnandjohn.nl/index.php?*wltypeid=1*
+// @include		http://www.sorcery101.net/*
+// @include		http://www.treadingground.com/*
+// @include		http://www.jerkcity.com/*
+// @include		http://jerkcity.com/*
+// @include		http://www.kiwiblitz.com/*
+// @include		http://thepunchlineismachismo.com/*
+// @include		http://kafkaskoffee.com/*
+// @include		http://occasionalcomics.com/*
+// @include		http://www.zombieboycomics.com/*
+// @include		http://www.babyblues.com/*
+// @include		http://babyblues.com/*
+// @include		http://www.bearandtiger.com/*
+// @include		http://mangatopia.net/*
+// @include		http*://exhentai.org/*
+// @include		http://www.wigucomics.com/*
+// @include		http://www.mankin-trad.net/*
+// @include		http://mankin-trad.net/*
+// @include		http://www.mangahere.co/*
+// @include		http://es.mangahere.co/*
+// @include		http://www.mangahere.cc/*
+// @include		http://es.mangahere.cc/*
+// @include		http://www.scarygoround.com/*
+// @include		http://scarygoround.com/*
+// @include		http://www.schlockmercenary.com/*
+// @include		http://www.warehousecomic.com/*
+// @include		http://warehousecomic.com/*
+// @include		http://www.tnemrot.com/*
+// @include		http://www.holiday-wars.com/*
+// @include		http://www.zapcomic.com/*
+// @include		http://www.twokinds.net/*
+// @include		http://twokinds.net/*
+// @include		http://www.dumbingofage.com/*
+// @include		http://www.shortpacked.com/*
+// @include		http://www.itswalky.com/*
+// @include		http://itswalky.com/*
+// @include		http://www.evildivacomics.com/*
+// @include		http://axecop.com/*
+// @include		http://www.somethingofthatilk.com/*
+// @include		http://somethingofthatilk.com/*
+// @include		http://www.reddit.com/
+// @include		http://www.reddit.com/?*
+// @include		http://www.reddit.com/r/*
+// @exclude		http://www.reddit.com/*/comments/*
+// @include		http://blankitcomics.com/*
+// @include		http://www.anime-source.com/*
+// @include		http://anime-source.com/*
+// @include		http://www.mangarush.com/*
+// @include		http://www.citymanga.com/*/*/*
+// @include		http://citymanga.com/*/*/*
+// @include		http://www.dctp.ws/*/V*.html
+// @include		http://dctp.ws/*/V*.html
+// @include		http://doctorcatmd.com/*
+// @include		http://www.sheldoncomics.com/*
+// @include		http://sheldoncomics.com/*
+// @include		http://luscious.net/*/pictures/*
+// @include		http://old.lu.scio.us/hentai/albums/*
+// @exclude		http://old.lu.scio.us/hentai/albums/*/page/*
+// @include		http://www.geekculture.com/joyoftech/*
+// @include		http://www.basketcasecomix.com/*
+// @include		http://www.geeklifecomic.com/*
+// @include		http://www.realmofatland.com/*
+// @include		http://realmofatland.com/*
+// @include		http://thedoujin.com/index.php/pages/*
+// @include		http://eatmanga.com/*
+// @include		http://eatmanga.me/*
+// @include		http://www.oslevadosdabreca.com/*
+// @include		http://www.thedevilbear.com/*
+// @include		http://thedevilbear.com/*
+// @include		http://www.bladebunny.com/*
+// @include		http://www.exiern.com/*
+// @include		http://nsfw-comix.com/*
+// @include		http://jaynaylor.com/*
+// @include		http://www.anelnoath.com/*
+// @include		http://www.faans.com/*
+// @include		http://www.truefork.org/*
+// @include		http://truefork.org/*
+// @include		http://www.aorange.com/*
+// @include		http*://www.thewotch.com/*
+// @include		http*://cheer.sailorsun.org/*
+// @include		http://montrose.is/sgvy/archives/*
+// @include		http://www.montrose.is/sgvy/archives/*
+// @include		http://www.drunkduck.com/*
+// @include		http://drunkduck.com/*
+// @include		http://www.ephralon.de/seekers_detailed.php*
+// @include		http://ephralon.de/seekers_detailed.php*
+// @include		http://www.terinu.com/*
+// @include		http://terinu.com/*
+// @include		http://dcisgoingtohell.com/*
+// @include		http://las-historietas.blogspot.com/*
+// @include		http://www.palcomix.com/*
+// @include		http://palcomix.com/*
+// @include		http://www.palcomix.org/*
+// @include		http://palcomix.org/*
+// @include		http://www.whiteninjacomics.com/*
+// @include		http://whiteninjacomics.com/*
+// @include		http://www.apenotmonkey.com/*
+// @include		http://malandchad.com/*
+// @include		http://www.goodmanga.net/*
+// @include		http://www.digitalcomicmuseum.com/*
+// @include		http://digitalcomicmuseum.com/*
+// @include		http://goldenagecomics.co.uk/*
+// @include		http://fourcolorshadows.blogspot.com/*
+// @include		http://thehorrorsofitall.blogspot.com/*
+// @include		*//bato.to/chapter*
+// @include		http://www.eegra.com/*
+// @include		http://www.octopuspie.com/*
+// @include		http://www.lovemenicecomic.com/*
+// @include		http://www.ju-ni.net/*
+// @include		http://ju-ni.net/*
+// @include		http://blog.saveapathea.com/*
+// @include		http://www.dead-philosophers.com/*
+// @include		http://www.nerd-theater.com/*
+// @include		http://nerd-theater.com/*
+// @include		http://lackadaisy.foxprints.com/comic.php*
+// @include		http://www.mangastream.to/*
+// @include		http://www.kingfeatures.com/*
+// @include		http://kingfeatures.com/*
+// @include		http://www.thezombiehunters.com/*
+// @include		http://thezombiehunters.com/*
+// @include		http://www.bugcomic.com/*
+// @include		http://www.interrobangstudios.com/*
+// @include		http://interrobangstudios.com/*
+// @include		http://www.hlcomic.com/*
+// @include		http://hlcomic.com/*
+// @include		http://syacartoonist.com/*
+// @include		http://satwcomic.com/*
+// @include		http://stupidfox.net/*
+// @include		http://www.casualvillain.com/*
+// @include		http://fanboys-online.com/*
+// @include		http://www.girlswithslingshots.com/*
+// @include		http://www.mntgaiden.com/*
+// @include		http://lovehentaimanga.com/*
+// @include		http://ravensdojo.com/*
+// @include		http://freefall.purrsia.com/*
+// @include		http://www.mangachapter.net/*
+// @include		http://www.mangachapter.me/*
+// @include		http://www.shd-wk.com/*
+// @include		http://shd-wk.com/*
+// @include		http://www.pepsaga.com/*
+// @include		http://slimythief.com/*
+// @include		http://www.pebbleversion.com/*
+// @include		http://pebbleversion.com/*
+// @include		http://mentalcatproductions.com/*
+// @include		http://schoolbites.net/*
+// @include		http://www.accurseddragon.com/*
+// @include		http://www.krakowstudios.com/*
+// @include		http://www.stringtheorycomic.com/*
+// @include		http://www.supercrash.net/*
+// @include		http://loveandcapes.com/*
+// @include		http://victorycomic.comicgenesis.com/*
+// @include		http://magellanverse.com/*
+// @include		http://www.evil-comic.com/*
+// @include		http://flakypastry.runningwithpencils.com/*
+// @include		http://www.pointguardian.com/*
+// @include		http://gogetaroomie.chloe-art.com/*
+// @include		http://legendofbill.com/*
+// @include		http://www.springiette.net/*
+// @include		http://springiette.net/*
+// @include		http://www.vampirecheerleaders.net/*
+// @include		http://www.paranormalmysterysquad.com/*
+// @include		http://www.draculaeverlasting.com/*
+// @include		http://www.amazingagentjennifer.com/*
+// @include		http://mindmistress.comicgenesis.com/*
+// @include		http://www.evernightcomic.com/*
+// @include		http://www.xindm.cn/*
+// @include		http://mh2.xindm.cn/*
+// @include		http://www.manga123.com/read/*
+// @include		http://manga.redhawkscans.com/*
+// @include		http://slide.extrascans.net/*
+// @include		http://*.thewebcomic.com/*
+// @include		http://www.mangapark.com/*
+// @include		http://mangapark.com/*
+// @include		http*://mangapark.me/*
+// @include		http://www.manga-go.com/*
+// @include		http://www.comicstriplibrary.org/display/*
+// @include		http://comicstriplibrary.org/display/*
+// @include		http://www.wirepop.com/*
+// @include		http://wirepop.com/*
+// @include		http://www.fantasyrealmsonline.com/manga/*
+// @include		http://foolrulez.org/*
+// @include		http://reader.japanzai.com/*
+// @include		http://www.psychopandas.com/reader/*
+// @include		http://psychopandas.com/reader/*
+// @include		http://www.ourmanga.com/*
+// @include		http://readonline.egscans.org/*
+// @include		http://read.egscans.com/*
+// @include		http://reader.eternalmanga.net/*
+// @include		http://gallery.ryuutama.com/*
+// @include		http://*.tiraecol.net/*
+// @include		http://tiraecol.net/*
+// @include		http://www.conejofrustrado.com/*
+// @include		http://www.e2w-illustration.com/*
+// @include		http://2gamerz.com/*
+// @include		http://reader.fth-scans.com/*
+// @include		http://www.simple-scans.com/*
+// @include		http://simple-scans.com/*
+// @include		http://www.mymangaspot.com/*
+// @include		http://comic.naver.com/*
+// @include		http://www.peteristhewolf.com/*
+// @include		http://peteristhewolf.com/*
+// @include		http://www.wlpcomics.com/*
+// @include		http://wlpcomics.com/*
+// @include		http://www.mangatraders.com/*
+// @include		http://hentaifromhell.net/*
+// @include		http://trenchescomic.com/*
+// @include		http://www.sakicow.com/reader/*
+// @include		http://sakicow.com/reader/*
+// @include		http://www.goominet.com/unspeakable-vault/*
+// @include		http://www.doesnotplaywellwithothers.com/*
+// @include		http://krakowstudios.com/*
+// @include		http://www.aikoniacomic.com/*
+// @include		http://aikoniacomic.com/*
+// @include		http*://grrlpowercomic.com/*
+// @include		http://www.poisonedminds.com/*
+// @include		http://poisonedminds.com/*
+// @include		http://nodwick.humor.gamespy.com/*
+// @include		http://www.the-whiteboard.com/*
+// @include		http://the-whiteboard.com/*
+// @include		http://www.mezzacotta.net/*
+// @include		http://www.hbrowse.com/*
+// @include		http://aptitude.surfacingpoint.com/*
+// @include		http://www.bardsworth.com/*
+// @include		http://fancyadventures.com/*
+// @include		http://www.chron.com/entertainment/comics-games/comic/*
+// @include		http://www.purplepussy.net/*
+// @include		http://purplepussy.net/*
+// @include		http://www.heroeslocales.com/bunsen/*
+// @include		http://www.readhentaionline.com/*
+// @include		http://readhentaionline.com/*
+// @include		http://www.darklegacycomics.com/*
+// @include		http://darklegacycomics.com/*
+// @include		http://candicomics.com/*
+// @include		http://www.buckocomic.com/*
+// @include		http://bearmageddon.com/*
+// @include		http://betweenfailures.net/*
+// @include		http://www.sisterclaire.com/*
+// @include		http://www.fayerwayer.com/*
+// @include		http://www.niubie.com/*
+// @include		http://www.awesomehospital.com/*
+// @include		http://ars.userfriendly.org/cartoons/*
+// @include		http://www.friendswithboys.com/*
+// @include		http://www.mangago.com/*
+// @include		http://www.jesusandmo.net/*
+// @include		http://www.calamitiesofnature.com/*
+// @include		http://www.rosalarian.com/*
+// @include		http://rosalarian.com/*
+// @include		http://dungeond.com/*
+// @include		http://www.irregularwebcomic.net/*
+// @include		http://adistantsoil.com/*
+// @include		http://comic.nodwick.com/*
+// @include		http://ffn.nodwick.com/*
+// @include		http://ps238.nodwick.com/*
+// @include		http://kronos.mcanime.net/*
+// @include		http://www.ghastlycomic.com/*
+// @include		http://thedevilspanties.com/*
+// @include		http://walkingdeadbr.com/*displayimage.php*
+// @include		http://www.mangapanda.com/*
+// @include		http://mangable.com/*
+// @include		http://dragonflyscans.org/*
+// @include		http://readincesthentai.com/*
+// @include		http://www.animephile.com/*
+// @include		http://hentaistreamer.com/*
+// @match		  *://kissmanga.com/*
+// @include		http://www.mangatank.com/*
+// @include		http://www.snowflakescomic.com/*
+// @include		http://mangafox.mobi/*
+// @include		http://www.mangainn.me/*
+// @include		http://invisiblebread.com/*
+// @include		http://onlinereader.mangapirate.net/*
+// @include		http://www.8comic.com/love/*
+// @include		http://8comic.com/love/*
+// @include		http://www.mangahead.com/*
+// @include		http://www.mangahead.me/*
+// @include		http://mangahead.com/*
+// @include		http://www.vickifox.com/*
+// @include		http://www.spinnyverse.com/*
+// @include		http://zenpencils.com/*
+// @include		http://wootmanga.com/*
+// @include		http://hentai2read.com/*
+// @include		http://m.hentai2read.com/*
+// @include		http://komikmy.com/*/*/*
+// @include		http://www.hentaifr.net/doujinshisheng.php*
+// @include		http://www.commissionedcomic.com/*
+// @include		http://www.mangasky.com/*
+// @include		http://mangapirate.net/*
+// @include		http://nomanga.com/*
+// @include		http://hentaimangaonline.com/*
+// @include		http://webcomics.yaoi911.com/*
+// @include		http://www.whompcomic.com/*
+// @include		http://actiontimebuddies.com/*
+// @include		http://www.superbrophybrothers.com/*
+// @include		http://www.surasplace.com/*
+// @include		http://surasplace.com/*
+// @include		http://fallensyndicate.com/reader/*
+// @include		http://www.nekothekitty.net/*
+// @include		http://curtailedcomic.com/*
+// @include		http://www.wiemanga.com/*
+// @include		http://img.wiemanga.com/*
+// @include		http://hentai4manga.com/*
+// @include		http://bradcolbow.com/*
+// @include		http://www.gaomanga.com/*
+// @include		http://www.theherobiz.com/*
+// @include		http://guildedage.net/*
+// @include		http://betweenfailures.com/*
+// @include		http://www.claudeandmonet.com/*
+// @include		http://phobia.subcultura.es/tira/*
+// @include		http://www.manga-tu.be/*
+// @include		http://de.ninemanga.com/*
+// @include		http://proxer.me/*
+// @include		http://www.demanga.com/*
+// @include		http://www.meinmanga.com/*
+// @include		http*://www.senmanga.com/*
+// @include		http*://raw.senmanga.com/*
+// @include		http://www.mangaesta.net/*
+// @include		http://www.mabuns.web.id/*
+// @include		http://www.manga4indo.com/*
+// @include		http://www.bloomingfaeries.com/*
+// @include		http://www.friendshipscans.com/*
+// @include		http://neechan.net/*
+// @include		http://www.komikid.com/*
+// @include		http://komikid.com/*
+// @include		http://blog.komikid.com/*
+// @include		http://www.findchaos.com/*
+// @include		http://chaoslife.findchaos.com/*
+// @include		http://moonoverjune.com/*
+// @include		http://www.shadbase.com/*
+// @include		http://www.shagbase.com/*
+// @include		http://www.mrlovenstein.com/*
+// @include		http://www.anticscomic.com/*
+// @include		http://octopuns.blogspot.com/*
+// @include		http://www.onemanga.me/*
+// @include		http://mangacow.co/*
+// @include		http://www.mangabee.com/*
+// @include		http://mangadoom.co/*
+// @include		http://www.powernapcomic.com/*
+// @include		http://mangachrome.com/*
+// @include		http://www.7manga.com/*
+// @include		http://7manga.com/*
+// @include		http://www.mangadevil.com/*
+// @include		http://mangadevil.com/*
+// @include		http://www.mangamofo.com/*
+// @include		http://*.hentai.ms/*
+// @include		http://view.mangamonger.com/*
+// @include		http://blackbird.ashen-ray.com/*
+// @include		http://carciphona.com/*
+// @include		http://ahs-comic.com/*
+// @include		http://www.gogetaroomie.com/*
+// @include		http://gogetaroomie.com/*
+// @include		http://*.thecomicseries.com/*
+// @include		http://www.sleepymaid.com/gallery/displayimage.php*
+// @include		http://sleepymaid.com/gallery/displayimage.php*
+// @include		http://www.squid-ops.com/*
+// @include		http://squid-ops.com/*
+// @include		http://www.endcomic.com/*
+// @include		http://www.thenoobcomic.com/*
+// @include		http://thenoobcomic.com/*
+// @include		http://zizki.com/*
+// @include		http://*.zizki.com/*
+// @include		http://pururin.com/*
+// @include		http://www.thedailyblink.com/*
+// @include		http://mangabandits.net/*
+// @include		http://www.neumanga.com/*
+// @include		http://www.pecintakomik.com/*
+// @include		http://www.schizmatic.com/*
+// @include		http://schizmatic.com/*
+// @include		http://www.yuri-ism.net/*
+// @include		http://www.bringbackroomies.com/*
+// @match		  *://*.blindsprings.com/*
+// @match		  *://*.forgottenordercomic.com/*
+// @include		http://www.wtfcomics.com/*archive.html?*
+// @include		http://wtfcomics.com/*archive.html?*
+// @include		http://www.olympusoverdrive.com/index.php?*
+// @include		http://olympusoverdrive.com/index.php?*
+// @include		http://*gucomics.com/*
+// @include		http://www.punksandnerds.com/*
+// @include		http://*.troutcave.net/*
+// @include		http://www.berserkersdaughter.com/*
+// @include		http://gingerhaze.com/nimona/comic/*
+// @include		http://aiacrowd.com/*
+// @include		http://aspect.waywardstudios.net/*
+// @include		http://chirault.sevensmith.net/*
+// @include		http://cucumber.gigidigi.com/*
+// @include		http://filteredfuzz.com/*
+// @include		http://www.dorktower.com/*
+// @include		http://mangajoy.com/*
+// @include		http://nhentai.net/*
+// @include		http://www.hejibits.com/*
+// @include		http://mangaindo.co/*
+// @include		http://5.79.87.81/*
+// @include		http://www.gao-subs.com/*
+// @include		http://www.mangawindow.com/*
+// @include		http://mangawindow.com/*
+// @include		http://omgmanga.com/*
+// @include		http://paintraincomic.com/*
+// @include		http://extrafabulouscomics.com/*
+// @include		http://hellocomic.com/*
+// @include		http://*.hellocomic.com/*
+// @include		http://www.feywinds.com/comic/*
+// @include		http://www.omgbeaupeep.com/*
+// @include		http://orgymania.net/*
+// @include		http://mspaintadventures.com/*
+// @include		http://www.mspaintadventures.com/*
+// @include		http://mspfanventures.com/
+// @include		http://agc.deskslave.org/comic_viewer.html
+// @include		http://www.readmanga.today/*
+// @include		http://www.mangatown.com/manga/*
+// @include		http://www.mymanga.me/manga/*
+// @include		http://www.legostargalactica.net/*
+// @include		http://hentaihere.com/m/*/*/*
+// @include		http://gomanga.co/reader/read*
+// @include		http://mangasee.co/manga/*
+// @include		http://mangaseeonline.us/*
+// @include		http://mangafap.com/image/*
+// @include		http://*.keenspot.com/*
+// @include		http://dynasty-scans.com/*
+// @include		http://*.dynasty-scans.com/*
+// @include		http://mangafast.online/manga/*
+// @include		http://www.demonicscans.com/FoOlSlide/read/*
+// @include		http://raws.yomanga.co/read/*
+// @include		http://*.dm5.com/m*
+// @include		https://nhentai.net/g/*
+// @include		http://www.marycagle.com/*
+// @include		http://www.sleeplessdomain.com/*
+// @include		http://www.webtoons.com/*
+// @match		  *://*.tsumino.com/Read/View/*
+// @include		http://incase.buttsmithy.com/comic/*
+// @include		http://leylinescomic.com/comics/*
+// @include		http://project-apollo.net/mos/*
+// @include		http://afterstrife.com/?p*
+// @include		https://hitomi.la/reader/*
+// @include		https://danbooru.donmai.us/*
+// @include		https://manga.madokami.al/reader/*
+// @match		  *://www.mngdoom.com/*/*
+// @match		  *://kimchicuddles.com/post/*
+// @match		  *://marktrail.com/*
+// @include		http*://www.atomic-robo.com/*
+// @include		http*://www.dhscomix.com/comics*
+// @include		http*://www.furaffinity.net/view/*
+// @include		http*://www.furaffinity.net/full/*
 // ==/UserScript==
 
 // End of includes
@@ -1639,7 +1639,7 @@ var paginas = [
 	},
 	{	url:	'*.katbox.net',
 		img:	[['.webcomic-image img']],
-        style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
+		style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
 	},
 	{	url:	'gipcomic.com',
 		img:	'/pages/',
@@ -2498,9 +2498,9 @@ var paginas = [
 		next:	'@rel="next"'
 	},
 	{	url:	'cheer.sailorsun.org',
-        img:	[['#comic img']],
-        back:   [[['.comic-nav-previous']]],
-        next:   [[['.comic-nav-next']]]
+		img:	[['#comic img']],
+		back:   [[['.comic-nav-previous']]],
+		next:   [[['.comic-nav-next']]]
 	},
 	{	url:	'drunkduck.com',
 		img:	[['#comic img']],
@@ -2528,10 +2528,10 @@ var paginas = [
 		extra:	[[['img[src^="comix/"]', '<br/>', 1]]]
 	},
 	{	url:	'thewotch.com',
-        back:   [[['.comic-nav-previous']]],
-        next:   [[['.comic-nav-next']]],
+		back:   [[['.comic-nav-previous']]],
+		next:   [[['.comic-nav-next']]],
 		extra:	[[['.comments']]],
-        style:	'#wcr_imagen{max-height:100% !important;max-width:90vw !important;width:auto !important;height:auto !important;}'
+		style:	'#wcr_imagen{max-height:100% !important;max-width:90vw !important;width:auto !important;height:auto !important;}'
 	},
 	{	url:	'thedevilbear.com',
 		img:	'comixx/'
@@ -4115,8 +4115,8 @@ var paginas = [
 	{	url:	'feywinds.com/comic',
 		img:	'../comic/pages'
 	},
-	{   url:    'omgbeaupeep.com',
-		img:    [['#omv .picture']],
+	{   url:	'omgbeaupeep.com',
+		img:	[['#omv .picture']],
 		back: function(html, pos) {
 			try {
 				return xpath('//a[img[@alt="Previous Page"]]/@href', html);
@@ -4133,7 +4133,7 @@ var paginas = [
 				return link[pos].replace(currChapter.value, currChapter.nextSibling.value).replace(/\/[^\/]*$/, "/1");
 			}
 		},
-	    extra: [[[".pager"]]],
+		extra: [[[".pager"]]],
 	},
  	{
 		url:	'orgymania.net',
@@ -4144,15 +4144,15 @@ var paginas = [
 	},
 	{
 		url:	'egscomics.com',
-		img:    [['#cc-comic']],
-        back:   [['.cc-prev']],
-        next:   [['.cc-next']],
-        first:	[['.cc-first']],
+		img:	[['#cc-comic']],
+		back:   [['.cc-prev']],
+		next:   [['.cc-next']],
+		first:	[['.cc-first']],
 		last:	[['.cc-last']],
 		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>'],
-        fixurl:	function(url, img, link){
+		fixurl:	function(url, img, link){
 					return url.replace('http://egscomics', 'http://www.egscomics');
-        }
+		}
 	},
 	{
 		url:	'http://mspfanventures.com/',
@@ -4185,7 +4185,7 @@ var paginas = [
 		first:	function(html){return "?goNumber=1";},
 		extra:	[function(html, pos){var comicNr = parseInt(link[pos].match(/\d+$/)[0]);
 										return '<div id="notes">'+link.extraNotes[comicNr] + '</div>';}],
-		style:	'#notes {\n    width: 600;\n    background-color: #ccc;\n    margin: auto;\n    text-align: left;\n}',
+		style:	'#notes {\n	width: 600;\n	background-color: #ccc;\n	margin: auto;\n	text-align: left;\n}',
 		layout:	false,
 	},
 	{
@@ -4283,18 +4283,18 @@ var paginas = [
 		url:	'mangatown.com/manga/',
 		img:	[['#image']],
 		back:	function(html, pos){try {
-			    return xpath('//div[@class="page_select"]/select/option[@selected]/preceding-sibling::option[1]/@value',html);
+				return xpath('//div[@class="page_select"]/select/option[@selected]/preceding-sibling::option[1]/@value',html);
 			} catch (e) {
-			    var chapterUrl = xpath('//h1/a/@href', html);
-			    var prevChapter = xpath('//select[@class="chapter_select"]/option[@value="' + chapterUrl + '"]/preceding-sibling::option[1]/@value');
-			    return prevChapter;
+				var chapterUrl = xpath('//h1/a/@href', html);
+				var prevChapter = xpath('//select[@class="chapter_select"]/option[@value="' + chapterUrl + '"]/preceding-sibling::option[1]/@value');
+				return prevChapter;
 			}},
 		next:	function(html, pos){try {
-			    return xpath('//div[@class="page_select"]/select/option[@selected]/following-sibling::option[1]/@value',html);
+				return xpath('//div[@class="page_select"]/select/option[@selected]/following-sibling::option[1]/@value',html);
 			} catch (e) {
-			    var chapterUrl = xpath('//h1/a/@href', html);
-			    var nextChapter = xpath('//select[@class="chapter_select"]/option[@value="' + chapterUrl + '"]/following-sibling::option[1]/@value');
-			    return nextChapter;
+				var chapterUrl = xpath('//h1/a/@href', html);
+				var nextChapter = xpath('//select[@class="chapter_select"]/option[@value="' + chapterUrl + '"]/following-sibling::option[1]/@value');
+				return nextChapter;
 			}},
 		first:	['//div[@class="page_select"]/select/option[1]/@value'],
 		last:	['//div[@class="page_select"]/select/option[last()]/@value'],
@@ -4572,7 +4572,7 @@ var paginas = [
 				  		req.open('GET', process_url);
 				  		req.send();
 					}
-		                },
+						},
 		style:	'#wcr_botones{color:black}',
 	},
 	{
@@ -4729,17 +4729,17 @@ var paginas = [
 				var pageCh = link[pos].match(/(\d+)\/(\d+)$/);
 				var chapter, page;
 				if (pageCh) {
-				    chapter = +pageCh[1];
-				    page = +pageCh[2];
+					chapter = +pageCh[1];
+					page = +pageCh[2];
 				}
 				var images = JSON.parse(html.match(/var images = ([^;]*)/)[1]).map(x=>x.url);
 				
 				var prev_ch = html.match(/var prev_chapter_url = '([^']*)'/);
 				
 				if (page <= 1) {
-				    return prev_ch[1];
+					return prev_ch[1];
 				} else {
-				    return link[pos].replace(/(\d+)\/(\d+)$/, chapter + "/" + (page - 1));
+					return link[pos].replace(/(\d+)\/(\d+)$/, chapter + "/" + (page - 1));
 				}
 				},
 		next:	function(html, pos){
@@ -4772,28 +4772,29 @@ var paginas = [
 		url:	'marktrail.com',
 		img:	[['#comic img']],
 	},
-    {	url:    'atomic-robo.com',
-        img:    [['#cc-comic']],
-        back:   [['.cc-prev']],
-        next:   [['.cc-next']],
-        first:	[['.cc-first']],
+	{	url:	'atomic-robo.com',
+		img:	[['#cc-comic']],
+		back:   [['.cc-prev']],
+		next:   [['.cc-next']],
+		first:	[['.cc-first']],
 		last:	[['.cc-last']],
-        style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
+		style:	'#wcr_imagen{height:auto !important;width:auto !important;}'
 	},
-    {	url:    'dhscomix.com/comics',
-        img:    ['div[@id="content"]//img'],
-        back:	'img[contains(@src, "nav_prevpage")]',
+	{	url:	'dhscomix.com/comics',
+		img:	['div[@id="content"]//img'],
+		back:	'img[contains(@src, "nav_prevpage")]',
 		next:	'img[contains(@src, "nav_nextpage")]',
 		first:	'img[contains(@src, "nav_firstpage")]',
 		last:	'img[contains(@src, "nav_newpage")]'
 	},
-    {	url:    'furaffinity.net',
-        img:    [['#submissionImg']],
-        back:	['//span[@class="parsed_nav_links"]//a[contains(.,"PREV")]'],
-        next:	['//span[@class="parsed_nav_links"]//a[contains(.,"NEXT")]'],
-		first:	['//span[@class="parsed_nav_links"]//a[contains(.,"FIRST")]']
+	{	url:	'furaffinity.net',
+		img:	[['#submissionImg']],
+		back:	['//span[@class="parsed_nav_links"]//a[contains(.,"PREV")]'],
+		next:	['//span[@class="parsed_nav_links"]//a[contains(.,"NEXT")]'],
+		first:	['//span[@class="parsed_nav_links"]//a[contains(.,"FIRST")]'],
+		extra:  [['//table[@class="maintable"]//tbody//tr//table[@class="maintable"]']]
 	}
-    // End of sites
+	// End of sites
 	/*
 	,
 	{	url:	'',
@@ -5126,8 +5127,8 @@ function run_script(){
 function fixbadjs(){
 	try{
 		var uw = typeof unsafeWindow !== "undefined"?unsafeWindow:window;
-	    // breakbadtoys is injected by jumpbar.js from TheHiveWorks
-	    // killbill and bucheck are injected by ks_headbar.js from Keenspot
+		// breakbadtoys is injected by jumpbar.js from TheHiveWorks
+		// killbill and bucheck are injected by ks_headbar.js from Keenspot
 		var badFunctions = ["breakbadtoys2", "killbill", "bucheck"];
 		for (var i = 0; i < badFunctions.length; i++) {
 			var name = badFunctions[i];
@@ -5337,11 +5338,11 @@ function setear(html, pos, dir){
 		catch(ex){
 			try{ titulo[pos] = match(html, /<title>(.+?)<\/title>/i, 1); }
 			catch(e){
-                try{ titulo[pos] = match(html, /document.title = '([^']+?)'/, 1); }
-                catch(e){
-                    error('set['+pos+']/titulo: ', e);
-                    titulo[pos] = link[pos];
-                }
+				try{ titulo[pos] = match(html, /document.title = '([^']+?)'/, 1); }
+				catch(e){
+					error('set['+pos+']/titulo: ', e);
+					titulo[pos] = link[pos];
+				}
 			}
 		}
 
@@ -6014,14 +6015,14 @@ function keyupHandler(evt){
 
 // For pages wich runs javascript on intervals.
 function clearAllIntervals() {
-    for (var i = 1; i < 9999; i++)
-        window.clearInterval(i);
+	for (var i = 1; i < 9999; i++)
+		window.clearInterval(i);
 }
 
 // For pages wich runs javascript on timers.
 function clearAllTimers() {
-    for (var i = 1; i < 9999; i++)
-        window.clearTimer(i);
+	for (var i = 1; i < 9999; i++)
+		window.clearTimer(i);
 }
 
 //revisa si se apreto la tecla configurada
@@ -7997,12 +7998,12 @@ function strToRegexp(url){
 
 function printarPaginaCustom(custom){
 	changeQuote = function(x) { // Changes a double quoted string to a single quoted one
-	    return x.replace(/\\"/g, '"').replace(/\'/g, "\\'").replace(/^"|"$/g, "'");
+		return x.replace(/\\"/g, '"').replace(/\'/g, "\\'").replace(/^"|"$/g, "'");
 	};
 
 	function indent(x, n) {
-	    var indention = new Array((n||0) + 1).join("\t");
-	    return x.toString().replace(/\n/g,'\n'+ indention);
+		var indention = new Array((n||0) + 1).join("\t");
+		return x.toString().replace(/\n/g,'\n'+ indention);
 	}
 
 	function pretty(y) {
@@ -8023,7 +8024,7 @@ function printarPaginaCustom(custom){
 	for (var i in x) {
 		if (x[i].length === 0) continue;
 		var z1 = "\t\t" + i + ":\t" + pretty(x[i]) + ",\n";
-        z += z1;
+		z += z1;
 	}
 	z += "\t},\n";
 

--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -145,10 +145,7 @@ var defaultSettings = {
 // @include        http://www.arcamax.com/*
 // @include        http://www.nettserier.no/*
 // @include        http://nettserier.no/*
-// @include        http://www.nerfnow.com/*
-// @include        http://nerfnow.com/*
-// @exclude        http://www.nerfnow.com/*/comments*
-// @exclude        http://nerfnow.com/*/comments*
+// @include        http*://www.nerfnow.com/*
 // @include        http://www.virtualshackles.com/*
 // @include        http://www.little-gamers.com/*
 // @include        http://www.digitalunrestcomic.com/*
@@ -214,9 +211,9 @@ var defaultSettings = {
 // @include        http://lackadaisycats.com/comic.php*
 // @include        http://www.lukesurl.com/*
 // @include        http://mycardboardlife.com/*
-// @include        http://megatokyo.com/*
-// @include        http://www.megatokyo.it/*
-// @include        http://www.megatokyo.de/*
+// @include        http*://megatokyo.com/*
+// @include        http*://www.megatokyo.it/*
+// @include        http*://www.megatokyo.de/*
 // @include        http://ex2.unixmanga.net/*
 // @include        http://noreasoncomics.com/*
 // @include        http://www.pixelcomic.net/*
@@ -341,8 +338,7 @@ var defaultSettings = {
 // @include        http://memoria.valice.net/*
 // @include        http://www.twilightlady.com/*
 // @include        http://submanga.com/*
-// @include        http://e-hentai.org/s/*
-// @include        https://e-hentai.org/s/*
+// @include        http*://e-hentai.org/*
 // @include        http://crazytje.be/*
 // @include        http://www.tenmangas.com/*
 // @include        http://tenmangas.com/*
@@ -407,8 +403,7 @@ var defaultSettings = {
 // @include        http://babyblues.com/*
 // @include        http://www.bearandtiger.com/*
 // @include        http://mangatopia.net/*
-// @include        http://exhentai.org/s/*
-// @include        https://exhentai.org/s/*
+// @include        http*://exhentai.org/*
 // @include        http://www.wigucomics.com/*
 // @include        http://www.mankin-trad.net/*
 // @include        http://mankin-trad.net/*
@@ -474,10 +469,9 @@ var defaultSettings = {
 // @include        http://www.aorange.com/*
 // @include        http://www.thewotch.com/*
 // @include        http://thewotch.com/*
-// @include        http://www.cheercomic.com/*
-// @include        http://cheercomic.com/*
-// @include        http://www.sgvy.com/*
-// @include        http://sgvy.com/*
+// @include        http*://cheer.sailorsun.org/*
+// @include        http://montrose.is/sgvy/archives/*
+// @include        http://www.montrose.is/sgvy/archives/*
 // @include        http://www.drunkduck.com/*
 // @include        http://drunkduck.com/*
 // @include        http://www.ephralon.de/seekers_detailed.php*
@@ -609,7 +603,7 @@ var defaultSettings = {
 // @include        http://krakowstudios.com/*
 // @include        http://www.aikoniacomic.com/*
 // @include        http://aikoniacomic.com/*
-// @include        http://www.grrlpowercomic.com/*
+// @include        http*	://www.grrlpowercomic.com/*
 // @include        http://www.poisonedminds.com/*
 // @include        http://poisonedminds.com/*
 // @include        http://nodwick.humor.gamespy.com/*
@@ -1413,7 +1407,7 @@ var paginas = [
 		txtcol:	'#888'
 	},
 	{	url:	'misfile.com',
-		img:	'overlay.php?pageCalled'
+		img:	'comics/'
 	},
 	{	url:	'digitalunrestcomic.com',
 		img:	'strips/'
@@ -2499,10 +2493,10 @@ var paginas = [
 		back:	'@rel="prev"',
 		next:	'@rel="next"'
 	},
-	{	url:	'cheercomic.com',
-		img:	'comics/',
-		back:	'img[@id="navimg3"]',
-		next:	'img[@id="navimg4"]'
+	{	url:	'cheer.sailorsun.org',
+                img:	[['#comic img']],
+                back:   [[['.comic-nav-previous']]],
+                next:   [[['.comic-nav-next']]]
 	},
 	{	url:	'drunkduck.com',
 		img:	[['#comic img']],
@@ -2516,7 +2510,7 @@ var paginas = [
 	{	url:	'ephralon.de',
 		img:	'/seekers/'
 	},
-	{	url:	'sgvy.com',
+	{	url:	'http://www.montrose.is/sgvy/',
 		img:	[['#comic']]
 	},
 	{	url:	'truefork.org',
@@ -2530,10 +2524,10 @@ var paginas = [
 		extra:	[[['img[src^="comix/"]', '<br/>', 1]]]
 	},
 	{	url:	'thewotch.com',
-		img:	'comics/',
-		back:	'img[contains(@src,"nav_prevpage")]',
-		next:	'img[contains(@src,"nav_nextpage")]',
-		extra:	[[['.comments']]]
+                back:   [[['.comic-nav-previous']]],
+                next:   [[['.comic-nav-next']]],
+		extra:	[[['.comments']]],
+                style:	'#wcr_imagen{max-height:100% !important;max-width:90vw !important;width:auto !important;height:auto !important;}'
 	},
 	{	url:	'thedevilbear.com',
 		img:	'comixx/'


### PR DESCRIPTION
- Megatokyo
    ] switched over to https://, set include to be http*:// to solve and future proof

- GrrlPower
    ] switched over to https://, set include to be http*:// to solve and future proof

- The Wotch: 
    ] Fixed loading, as well implemented a max width since several images recently have been 2500+ wide
    ] Removed include for http://thewotch.com as that redirects to http://www.thewotch.com

- The Wotch: Cheer
    ] Fixed new URL
    ] other fixes to get script to run, since it switched to wordpress from whatever it was before

- SGVY: updated Includes to the new url at montrose.is/sgvy/archives

- Misfile: Fixed img url matching

- NerfNow!:  
    ] Fixed includes. 
    ] Remove redundant extra include as it redirects to the www prefix
    ] Removed the comment pages include (unable to get them to load)

- e-hentai:
    ] combined the two e-hentai includes to be a single under http*:// instead of https:// and http://
    ] removed the /s, as it was not needed, and limited where you could turn on the script if you're someone who doesn't keep it on 24/7

- exhentai: same changes as e-hentai.

Had to stop at this point, as I kept finding more and more. And I had yet had my dinner.