### PR TITLE
Fix egscomics.com – left-align the news text

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -4151,7 +4151,7 @@ var paginas = [
 		next:	'@rel="next"',
 		first:	'@rel="first"',
 		last:	'@rel="last"',
-		extra:	['<div id="wrapper"><div id="leftarea">',[['#news']],'</div></div>'],
+		extra:	['<div id="wrapper"><div id="leftarea" style="text-align: left">',[['#news']],'</div></div>'],
 	},
 	{
 		url:	'http://mspfanventures.com/',


### PR DESCRIPTION
The news text contains paragraphs of text, rather than a short title or label, so it should be left-aligned rather than centered.

An example page to see the difference on: http://egscomics.com/comic/party-022

This fix was made with the help of @m2pt5’s comment at https://github.com/anka-213/webcomic_reader/issues/118#issuecomment-416060104.

For commit searching: the comic is named El Goonish Shive.