### PR TITLE
Use real arrow symbols in the Site settings > Extra Content editor

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -5501,8 +5501,8 @@ function trExtraConfSitio(p, prop){
 	var tdsConf = tdsConfSitio(p, prop);
 	tds[0].innerHTML =
 		'<div style="float:right">'+
-			'<button id="wcr_btn_up_'+p+'">/\\</button>'+
-			'<button id="wcr_btn_down_'+p+'">\\/</button>'+
+			'<button id="wcr_btn_up_'+p+'">&#8593;</button>'+
+			'<button id="wcr_btn_down_'+p+'">&#8595;</button>'+
 			'<button id="wcr_btn_del_'+p+'">Delete</button>'+
 		'</div>';
 	tds[1].innerHTML = tdsConf[0];


### PR DESCRIPTION
### Before:

> /\\ \\/

> <img width="300" alt="Screen Shot 2020-03-12 at 9 26 55 PM Webcomic Reader arrows before" src="https://user-images.githubusercontent.com/79168/76581175-e48dc100-64a8-11ea-9231-7a66c500f505.png">

### After:

> ↑ ↓

> <img width="290" alt="Screen Shot 2020-03-12 at 9 26 24 PM Webcomic Reader arrows after" src="https://user-images.githubusercontent.com/79168/76581179-e9527500-64a8-11ea-8028-6ed3f2734dca.png">